### PR TITLE
Chore/dependency update 2026 04 24 di upgrade

### DIFF
--- a/.yarn/changelogs/common.0027ea0c.md
+++ b/.yarn/changelogs/common.0027ea0c.md
@@ -1,48 +1,8 @@
 <!-- version-type: patch -->
 # common
 
-<!--
-FORMATTING GUIDE:
-
-### Detailed Entry (appears first when merging)
-
-Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
-
-### Simple List Items
-
-- Simple changes can be added as list items
-- They are collected together at the bottom of each section
-
-TIP: When multiple changelog drafts are merged, heading-based entries
-appear before simple list items within each section.
--->
-
-## ✨ Features
-<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
-
-## 🐛 Bug Fixes
-<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
-
-## 📚 Documentation
-<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
-
-## ⚡ Performance
-<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
-
-## ♻️ Refactoring
-<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
-
-## 🧪 Tests
-<!-- PLACEHOLDER: Describe test changes (test:) -->
-
-## 📦 Build
-<!-- PLACEHOLDER: Describe build system changes (build:) -->
-
-## 👷 CI
-<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
-
 ## ⬆️ Dependencies
-<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
 
-## 🔧 Chores
-<!-- PLACEHOLDER: Describe other changes (chore:) -->
+- Bumped `@furystack/rest` from `^9.0.0` to `^10.0.0`. Version-only bump aligned with the v7 functional-DI release across the FuryStack workspace; no API in this package needed to change.
+- Bumped `@types/node` from `^25.5.0` to `^25.6.0`.
+- Bumped `vitest` from `^4.1.1` to `^4.1.5`.

--- a/.yarn/changelogs/common.0027ea0c.md
+++ b/.yarn/changelogs/common.0027ea0c.md
@@ -1,0 +1,48 @@
+<!-- version-type: patch -->
+# common
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ✨ Features
+<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
+
+## 🐛 Bug Fixes
+<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
+
+## 📚 Documentation
+<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
+
+## ⚡ Performance
+<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
+
+## ♻️ Refactoring
+<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+## 🧪 Tests
+<!-- PLACEHOLDER: Describe test changes (test:) -->
+
+## 📦 Build
+<!-- PLACEHOLDER: Describe build system changes (build:) -->
+
+## 👷 CI
+<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+
+## ⬆️ Dependencies
+<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
+
+## 🔧 Chores
+<!-- PLACEHOLDER: Describe other changes (chore:) -->

--- a/.yarn/changelogs/frontend.0027ea0c.md
+++ b/.yarn/changelogs/frontend.0027ea0c.md
@@ -1,48 +1,65 @@
 <!-- version-type: patch -->
 # frontend
 
-<!--
-FORMATTING GUIDE:
-
-### Detailed Entry (appears first when merging)
-
-Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
-
-### Simple List Items
-
-- Simple changes can be added as list items
-- They are collected together at the bottom of each section
-
-TIP: When multiple changelog drafts are merged, heading-based entries
-appear before simple list items within each section.
--->
-
-## ✨ Features
-<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
-
-## 🐛 Bug Fixes
-<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
-
-## 📚 Documentation
-<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
-
-## ⚡ Performance
-<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
-
 ## ♻️ Refactoring
-<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+### Migrated `SessionService` and `BoilerplateApiClient` to functional DI
+
+`@furystack/inject` v13 dropped decorator-based DI. Both browser-side singletons were rewritten as `defineService` tokens:
+
+- `BoilerplateApiClient` now builds the JWT token store, JWT REST client and authorized REST client inside its `factory`, and exposes them through a typed object literal (with a getter that proxies `tokenStore.isAuthenticated`). The previous `@Injectable` class plus the module-scope `tokenStore` / `authorizedClient` constants are gone.
+- `SessionService` now exposes its surface as an `interface SessionService extends IdentityContext { … }` plus a matching `defineService` token. The factory wires `BoilerplateApiClient` and `NotyService` via `inject(...)`, registers the `ObservableValue` disposals through `onDispose`, and kicks off `void init()` so the bootstrap fetch runs without an explicit consumer call (the previous `init()` method was unreachable from production code).
+
+```ts
+// before
+@Injectable({ lifetime: 'singleton' })
+export class SessionService implements IdentityContext, Disposable {
+  @Injected(BoilerplateApiClient)
+  declare private api: BoilerplateApiClient
+  // …
+}
+shadeInjector.getInstance(SessionService)
+
+// after
+export const SessionService: Token<SessionService, 'singleton'> = defineService({
+  name: 'app/SessionService',
+  lifetime: 'singleton',
+  factory: ({ inject, onDispose }) => {
+    const api = inject(BoilerplateApiClient)
+    // …
+    void init()
+    return { state, currentUser, isOperationInProgress, loginError, init, login, logout, isAuthenticated, isAuthorized, getCurrentUser }
+  },
+})
+shadeInjector.get(SessionService)
+```
+
+### Updated every Shade component to resolve services via `injector.get`
+
+`Layout`, `Header`, `Sidebar`, `ThemeSwitch`, `GithubLogo`, the login page and the hello-world page swapped `injector.getInstance(X)` for `injector.get(X)` to match the new injector surface.
+
+### Bootstrap hardening in `index.tsx`
+
+- `new Injector()` → `createInjector()`.
+- `document.getElementById('root')` is now null-checked with a clear error instead of silently casting through `as HTMLDivElement`.
+- The throw-by-default `SessionService` resolution still triggers the eager `init()` so the app reaches the `Layout` switch with a real auth state on first paint.
+
+### Cleaned up `frontend/tsconfig.json`
+
+Now extends the workspace root `tsconfig.json` and only overrides the frontend-specific bits (`outDir`, `composite`, `declaration`, `declarationMap`, `jsx`, `jsxFactory`, `jsxFragmentFactory`, `lib`, `pretty`, `types: []`). Removed every option that already lived in the root tsconfig.
 
 ## 🧪 Tests
-<!-- PLACEHOLDER: Describe test changes (test:) -->
 
-## 📦 Build
-<!-- PLACEHOLDER: Describe build system changes (build:) -->
-
-## 👷 CI
-<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+- Added `frontend/src/services/session.spec.ts` — covers the auto-init paths (`unauthenticated` / `authenticated` / `offline`), `login` success + failure (state + noty assertions), `logout`, and `isAuthorized` role matching, all driven by `injector.bind(BoilerplateApiClient, …)` / `injector.bind(NotyService, …)` mocks.
+- Added `frontend/src/services/boilerplate-api-client.spec.ts` — verifies the token resolves to a singleton with the expected surface, that `login` POSTs to `/jwt/login` and flips `isAuthenticated` (using a synthesized JWT with a future `exp`), and that `setTokens` activates the authenticated state without touching `fetch`.
 
 ## ⬆️ Dependencies
-<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
 
-## 🔧 Chores
-<!-- PLACEHOLDER: Describe other changes (chore:) -->
+- Bumped `@furystack/auth-jwt` from `^3.0.0` to `^4.0.0` (functional-DI v7 release; client-side `createJwtTokenStore` / `createJwtClient` shapes unchanged).
+- Bumped `@furystack/core` from `^16.0.4` to `^17.0.0` (`IdentityContext` is now an interface; satisfied by `SessionService`'s returned object).
+- Bumped `@furystack/inject` from `^12.0.36` to `^13.0.0`.
+- Bumped `@furystack/logging` from `^8.1.5` to `^9.0.0`.
+- Bumped `@furystack/rest-client-fetch` from `^8.1.8` to `^9.0.0`.
+- Bumped `@furystack/shades` from `^14.0.0` to `^15.0.0` (services declassed to plain-object factories behind tokens; `LocationService` is resolved by token).
+- Bumped `@furystack/shades-common-components` from `^16.0.0` to `^17.0.0` (`ThemeProviderService` / `NotyService` now tokens; `LayoutService` is scoped to `<PageLayout>`).
+- Bumped `@furystack/utils` from `^8.2.5` to `^9.0.0`.

--- a/.yarn/changelogs/frontend.0027ea0c.md
+++ b/.yarn/changelogs/frontend.0027ea0c.md
@@ -1,0 +1,48 @@
+<!-- version-type: patch -->
+# frontend
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ✨ Features
+<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
+
+## 🐛 Bug Fixes
+<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
+
+## 📚 Documentation
+<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
+
+## ⚡ Performance
+<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
+
+## ♻️ Refactoring
+<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+## 🧪 Tests
+<!-- PLACEHOLDER: Describe test changes (test:) -->
+
+## 📦 Build
+<!-- PLACEHOLDER: Describe build system changes (build:) -->
+
+## 👷 CI
+<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+
+## ⬆️ Dependencies
+<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
+
+## 🔧 Chores
+<!-- PLACEHOLDER: Describe other changes (chore:) -->

--- a/.yarn/changelogs/furystack-boilerplate-app.0027ea0c.md
+++ b/.yarn/changelogs/furystack-boilerplate-app.0027ea0c.md
@@ -1,48 +1,47 @@
 <!-- version-type: patch -->
 # furystack-boilerplate-app
 
-<!--
-FORMATTING GUIDE:
-
-### Detailed Entry (appears first when merging)
-
-Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
-
-### Simple List Items
-
-- Simple changes can be added as list items
-- They are collected together at the bottom of each section
-
-TIP: When multiple changelog drafts are merged, heading-based entries
-appear before simple list items within each section.
--->
-
-## ✨ Features
-<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
-
-## 🐛 Bug Fixes
-<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
-
-## 📚 Documentation
-<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
-
-## ⚡ Performance
-<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
-
 ## ♻️ Refactoring
-<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
 
-## 🧪 Tests
-<!-- PLACEHOLDER: Describe test changes (test:) -->
+### Tightened the workspace `tsconfig.json`
+
+Dropped the redundant `incremental`, `composite`, `moduleResolution` and `allowSyntheticDefaultImports` lines (already covered by `module: "NodeNext"` plus `esModuleInterop`), and switched to `files: []` + `references: [./common, ./service, ./frontend]` so a top-level `tsc -b` builds every workspace through TypeScript's project-references model.
+
+### Switched the Vitest frontend project from `jsdom` to `happy-dom`
+
+`jsdom@29` ships an ESM-only `html-encoding-sniffer@6`, which `require()` cannot load on Node 20.x. Swapping the frontend project's `environment` to `happy-dom` fixes the test pool startup, removes the heavyweight jsdom dependency tree, and keeps the DOM surface needed by the new frontend specs intact.
+
+```diff
+ {
+   test: {
+     name: 'Frontend',
+-    environment: 'jsdom',
++    environment: 'happy-dom',
+     include: ['frontend/src/**/*.spec.(ts|tsx)'],
+   },
+ }
+```
 
 ## 📦 Build
-<!-- PLACEHOLDER: Describe build system changes (build:) -->
 
-## 👷 CI
-<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+### Allowed default project resolution for top-level config files in ESLint
+
+`eslint.config.js` now passes `parserOptions.projectService.allowDefaultProject` listing `vite.config.ts`, `vitest.config.mts`, `playwright.config.ts`, `frontend/vite.config.ts` and `e2e/*.spec.ts`. These files were previously reported as `Parsing error: … was not found by the project service` because none of the `tsconfig.json` `include` globs covered them; lint is now clean for the whole repository.
 
 ## ⬆️ Dependencies
-<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
 
-## 🔧 Chores
-<!-- PLACEHOLDER: Describe other changes (chore:) -->
+- Added `happy-dom` (replaces `jsdom` for the Vitest frontend project — see Refactoring above).
+- Bumped `@furystack/eslint-plugin` from `^2.1.3` to `^3.0.0` (functional-DI v7 release of the lint rules).
+- Bumped `@furystack/yarn-plugin-changelog` from `^1.0.8` to `^1.0.10`.
+- Bumped `@playwright/test` from `^1.58.2` to `^1.59.1`.
+- Bumped `@types/node` from `^25.5.0` to `^25.6.0`.
+- Bumped `@vitest/coverage-v8` from `^4.1.1` to `^4.1.5`.
+- Bumped `eslint` from `^10.1.0` to `^10.2.1`.
+- Bumped `eslint-plugin-jsdoc` from `^62.8.0` to `^62.9.0`.
+- Bumped `eslint-plugin-playwright` from `^2.10.1` to `^2.10.2`.
+- Bumped `prettier` from `^3.8.1` to `^3.8.3`.
+- Bumped `typescript` from `^6.0.2` to `^6.0.3`.
+- Bumped `typescript-eslint` from `^8.57.2` to `^8.59.0`.
+- Bumped `vite` from `^8.0.2` to `^8.0.10`.
+- Bumped `vitest` from `^4.1.1` to `^4.1.5`.
+- Bumped Yarn from `4.13.0` to `4.14.1`.

--- a/.yarn/changelogs/furystack-boilerplate-app.0027ea0c.md
+++ b/.yarn/changelogs/furystack-boilerplate-app.0027ea0c.md
@@ -1,0 +1,48 @@
+<!-- version-type: patch -->
+# furystack-boilerplate-app
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ✨ Features
+<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
+
+## 🐛 Bug Fixes
+<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
+
+## 📚 Documentation
+<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
+
+## ⚡ Performance
+<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
+
+## ♻️ Refactoring
+<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+## 🧪 Tests
+<!-- PLACEHOLDER: Describe test changes (test:) -->
+
+## 📦 Build
+<!-- PLACEHOLDER: Describe build system changes (build:) -->
+
+## 👷 CI
+<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+
+## ⬆️ Dependencies
+<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
+
+## 🔧 Chores
+<!-- PLACEHOLDER: Describe other changes (chore:) -->

--- a/.yarn/changelogs/service.0027ea0c.md
+++ b/.yarn/changelogs/service.0027ea0c.md
@@ -1,48 +1,88 @@
 <!-- version-type: patch -->
 # service
 
-<!--
-FORMATTING GUIDE:
-
-### Detailed Entry (appears first when merging)
-
-Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
-
-### Simple List Items
-
-- Simple changes can be added as list items
-- They are collected together at the bottom of each section
-
-TIP: When multiple changelog drafts are merged, heading-based entries
-appear before simple list items within each section.
--->
-
-## ✨ Features
-<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
-
-## 🐛 Bug Fixes
-<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
-
-## 📚 Documentation
-<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
-
-## ⚡ Performance
-<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
-
 ## ♻️ Refactoring
-<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+### Migrated the persistence layer to functional DI
+
+`@furystack/core` v17, `@furystack/repository` v11, `@furystack/rest-service` v14, `@furystack/security` v8, `@furystack/auth-jwt` v4 and `@furystack/filesystem-store` v8 replaced the old `addStore` / `getRepository().createDataSet(...)` pipeline with module-scoped `defineStore` / `defineFileSystemStore` / `defineDataSet` tokens. `setup-store.ts` was rewritten to:
+
+- Declare module-scoped `defineFileSystemStore` tokens for the persisted user / password-credential collections and `defineStore` tokens for the in-memory session / password-reset-token / refresh-token collections.
+- Bind the framework-provided throw-by-default tokens (`UserStore`, `SessionStore`, `PasswordCredentialStore`, `PasswordResetTokenStore`, `RefreshTokenStore`) to those backing stores via `injector.bind(token, ({ inject }) => inject(BackingToken))`, so disposal is owned by the backing `defineStore` / `defineFileSystemStore` factory.
+- Expose a single `AuthorizedUserDataSet` (`defineDataSet({ store: UserStore, settings: authorizedDataSet })`) and pass it to `useHttpAuthentication(injector, { userDataSet: AuthorizedUserDataSet })`. The same token is reused by the seeder so write-time authorization runs through one pipeline.
+
+```ts
+// before
+addStore(injector, new FileSystemStore({ model: User, primaryKey: 'username', ... }))
+  .addStore(new InMemoryStore({ model: DefaultSession, primaryKey: 'sessionId' }))
+  // …
+getRepository(injector)
+  .createDataSet(User, 'username', { ...authorizedDataSet })
+  // …
+useHttpAuthentication(injector)
+
+// after
+const UsersFileStore = defineFileSystemStore({ name: 'app/UsersFileStore', model: User, primaryKey: 'username', fileName: usersFile, tickMs: 30_000 })
+// … other backing tokens …
+
+export const AuthorizedUserDataSet = defineDataSet({ name: 'app/AuthorizedUserDataSet', store: UserStore, settings: authorizedDataSet })
+
+export const setupStore = (injector: Injector): void => {
+  injector.bind(UserStore, ({ inject }) => inject(UsersFileStore))
+  // … other bindings …
+  useHttpAuthentication(injector, { userDataSet: AuthorizedUserDataSet })
+}
+```
+
+### Replaced the seed-time direct service lookups with token resolution
+
+`seed.ts` no longer goes through `getDataSetFor(injector, Model, 'pk')` or `injector.getInstance(PasswordAuthenticator)`. It now resolves the new `AuthorizedUserDataSet` and `PasswordCredentialDataSet` tokens directly through `injector.get(...)` inside a `useSystemIdentityContext` scope.
+
+### Hardened JWT secret loading
+
+`requireJwtSecret(env)` validates the JWT signing secret at startup:
+
+- Returns `process.env.JWT_SECRET` when its UTF-8 byte length is at least 32.
+- Throws when `NODE_ENV === 'production'` and the env var is missing or too short, so a misconfigured deploy fails loudly instead of silently using the development fallback.
+- Falls back to a fixed development secret in any other environment, matching the previous local-dev experience.
+
+The byte-length check matches the 32-byte invariant `useJwtAuthentication` enforces, so multi-byte UTF-8 secrets that happened to have ≥ 32 characters but < 32 bytes are now rejected before reaching the framework.
+
+### Simplified the shutdown handler
+
+`@furystack/rest-service` v14 removed the `ServerManager` class — the HTTP server pool is owned by `HttpServerPoolToken` and disposes itself when the injector is disposed. `attachShutdownHandler` no longer probes `cachedSingletons` for `ServerManager`; every signal handler now just calls `await injector[Symbol.asyncDispose]()` and exits. The error-data shape on the fatal log was tightened with `instanceof Error` checks instead of `// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access` casts.
+
+### Split the seed entry point from its library exports
+
+`seed.ts` is now a pure module exporting `getOrCreate` and `seed`. The bootstrap (`setupStore(injector)` → `seed(injector)` → dispose) moved to `service/src/bin/seed.ts`. The `seed` script in `service/package.json` was repointed accordingly:
+
+```jsonc
+{
+  "scripts": {
+    "seed": "yarn node ./dist/bin/seed.js"
+  }
+}
+```
+
+This keeps the library importable from tests (and other tooling) without triggering the side-effectful `useJwtAuthentication` / file watcher startup at import time.
+
+### Removed the no-op `config.spec.ts`
+
+Replaced with real specs for the migrated modules (see the Tests section). The old placeholder used `expect(true)` without a matcher and would have passed even if `true` were replaced with `false`.
 
 ## 🧪 Tests
-<!-- PLACEHOLDER: Describe test changes (test:) -->
 
-## 📦 Build
-<!-- PLACEHOLDER: Describe build system changes (build:) -->
-
-## 👷 CI
-<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+- Added `service/src/setup-store.spec.ts` — covers `requireJwtSecret` (env var resolution, byte-length boundary at 32, multi-byte UTF-8, dev fallback, production throw) and a smoke test that verifies `setupStore(injector)` binds every framework store token plus rebinds `HttpAuthenticationSettings` with the exported `AuthorizedUserDataSet`.
+- Added `service/src/seed.spec.ts` — covers the three branches of `getOrCreate` (existing single match returns as-is; empty result inserts the supplied instance; ambiguous result logs a warning and returns the first hit).
+- Added `service/src/shutdown-handler.spec.ts` — captures the registered `process.once` listeners and verifies that each signal disposes the injector exactly once, exits with the expected code, and falls back to `process.exit(1)` when disposal itself rejects.
 
 ## ⬆️ Dependencies
-<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
 
-## 🔧 Chores
-<!-- PLACEHOLDER: Describe other changes (chore:) -->
+- Bumped `@furystack/auth-jwt` from `^3.0.0` to `^4.0.0` (functional-DI v7 release; settings, token service and refresh-token store are now DI tokens).
+- Bumped `@furystack/core` from `^16.0.4` to `^17.0.0` (`StoreManager` removed in favour of `defineStore`; `Constructable` moved here from `@furystack/inject`).
+- Bumped `@furystack/filesystem-store` from `^7.1.7` to `^8.0.0` (`useFileSystemStore` removed in favour of `defineFileSystemStore`).
+- Bumped `@furystack/inject` from `^12.0.36` to `^13.0.0` (decorator-based DI removed; `defineService` / `createInjector` / `injector.get` / `injector.bind` is the new surface).
+- Bumped `@furystack/logging` from `^8.1.5` to `^9.0.0`.
+- Bumped `@furystack/repository` from `^10.1.11` to `^11.0.0` (`Repository` removed in favour of `defineDataSet`).
+- Bumped `@furystack/rest-service` from `^13.0.0` to `^14.0.0` (`ServerManager` / `ApiManager` / `StaticServerManager` / `ProxyManager` removed; subsystems are tokens now).
+- Bumped `@furystack/security` from `^7.0.9` to `^8.0.0` (password authenticator and hasher are tokens; `PasswordCredentialStore` / `PasswordResetTokenStore` are throw-by-default).

--- a/.yarn/changelogs/service.0027ea0c.md
+++ b/.yarn/changelogs/service.0027ea0c.md
@@ -1,0 +1,48 @@
+<!-- version-type: patch -->
+# service
+
+<!--
+FORMATTING GUIDE:
+
+### Detailed Entry (appears first when merging)
+
+Use h3 (###) and below for detailed entries with paragraphs, code examples, and lists.
+
+### Simple List Items
+
+- Simple changes can be added as list items
+- They are collected together at the bottom of each section
+
+TIP: When multiple changelog drafts are merged, heading-based entries
+appear before simple list items within each section.
+-->
+
+## ✨ Features
+<!-- PLACEHOLDER: Describe your shiny new features (feat:) -->
+
+## 🐛 Bug Fixes
+<!-- PLACEHOLDER: Describe the nasty little bugs that has been eradicated (fix:) -->
+
+## 📚 Documentation
+<!-- PLACEHOLDER: Describe documentation changes (docs:) -->
+
+## ⚡ Performance
+<!-- PLACEHOLDER: Describe performance improvements (perf:) -->
+
+## ♻️ Refactoring
+<!-- PLACEHOLDER: Describe code refactoring (refactor:) -->
+
+## 🧪 Tests
+<!-- PLACEHOLDER: Describe test changes (test:) -->
+
+## 📦 Build
+<!-- PLACEHOLDER: Describe build system changes (build:) -->
+
+## 👷 CI
+<!-- PLACEHOLDER: Describe CI configuration changes (ci:) -->
+
+## ⬆️ Dependencies
+<!-- PLACEHOLDER: Describe dependency updates (deps:) -->
+
+## 🔧 Chores
+<!-- PLACEHOLDER: Describe other changes (chore:) -->

--- a/.yarn/versions/0027ea0c.yml
+++ b/.yarn/versions/0027ea0c.yml
@@ -1,0 +1,5 @@
+releases:
+  common: patch
+  frontend: patch
+  furystack-boilerplate-app: patch
+  service: patch

--- a/common/package.json
+++ b/common/package.json
@@ -30,6 +30,6 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@furystack/rest": "^9.0.0"
+    "@furystack/rest": "^10.0.0"
   }
 }

--- a/common/schemas/boilerplate-api.json
+++ b/common/schemas/boilerplate-api.json
@@ -134,7 +134,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -149,7 +164,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -164,7 +194,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -179,7 +224,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -194,7 +254,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -209,7 +284,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -224,7 +314,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -239,7 +344,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -445,7 +565,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -460,7 +595,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -475,7 +625,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -490,7 +655,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -505,7 +685,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -520,7 +715,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -535,7 +745,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false

--- a/common/schemas/jwt-api.json
+++ b/common/schemas/jwt-api.json
@@ -14,7 +14,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -117,7 +132,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -132,7 +162,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -147,7 +192,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -162,7 +222,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -177,7 +252,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -192,7 +282,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false
@@ -207,7 +312,22 @@
               "url": {},
               "query": {},
               "body": {},
-              "headers": {}
+              "headers": {},
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deprecated": {
+                "type": "boolean"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
             },
             "required": ["result"],
             "additionalProperties": false

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,7 +43,15 @@ export default tseslint.config(
     },
     languageOptions: {
       parserOptions: {
-        projectService: true,
+        projectService: {
+          allowDefaultProject: [
+            'vite.config.ts',
+            'vitest.config.mts',
+            'playwright.config.ts',
+            'frontend/vite.config.ts',
+            'e2e/*.spec.ts',
+          ],
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,14 +17,14 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@furystack/auth-jwt": "^3.0.0",
-    "@furystack/core": "^16.0.4",
-    "@furystack/inject": "^12.0.36",
-    "@furystack/logging": "^8.1.5",
-    "@furystack/rest-client-fetch": "^8.1.8",
-    "@furystack/shades": "^14.0.0",
-    "@furystack/shades-common-components": "^16.0.0",
-    "@furystack/utils": "^8.2.5",
+    "@furystack/auth-jwt": "^4.0.0",
+    "@furystack/core": "^17.0.0",
+    "@furystack/inject": "^13.0.0",
+    "@furystack/logging": "^9.0.0",
+    "@furystack/rest-client-fetch": "^9.0.0",
+    "@furystack/shades": "^15.0.0",
+    "@furystack/shades-common-components": "^17.0.0",
+    "@furystack/utils": "^9.0.0",
     "@types/node": "^25.6.0",
     "common": "workspace:^"
   }

--- a/frontend/src/components/github-logo/index.tsx
+++ b/frontend/src/components/github-logo/index.tsx
@@ -14,7 +14,7 @@ export const GithubLogo = Shade<GithubLogoProps>({
   customElementName: 'github-logo',
 
   render: ({ props, useDisposable, useState, injector }) => {
-    const themeProvider = injector.getInstance(ThemeProviderService)
+    const themeProvider = injector.get(ThemeProviderService)
     const [theme, setTheme] = useState('themeName', getTextColor(themeProvider.theme.background.paper, 'light', 'dark'))
     useDisposable('themeChange', () =>
       themeProvider.subscribe('themeChanged', () => {

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -24,7 +24,7 @@ export const Header = Shade({
               <GithubLogo style={{ height: '25px' }} />
             </Button>
           </a>
-          <Button variant="outlined" onclick={() => injector.getInstance(SessionService).logout()}>
+          <Button variant="outlined" onclick={() => injector.get(SessionService).logout()}>
             Log Out
           </Button>
         </div>

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -18,7 +18,7 @@ const appRoutes = {
 export const Layout = Shade({
   customElementName: 'shade-app-layout',
   render: ({ injector, useObservable }) => {
-    const session = injector.getInstance(SessionService)
+    const session = injector.get(SessionService)
     const [sessionState] = useObservable('sessionState', session.state)
 
     return (

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -15,7 +15,7 @@ export const Sidebar = Shade({
     padding: '8px 0',
   },
   render: ({ injector, useObservable }) => {
-    const locationService = injector.getInstance(LocationService)
+    const locationService = injector.get(LocationService)
     const [currentPath] = useObservable('currentPath', locationService.onLocationPathChanged)
 
     return (

--- a/frontend/src/components/theme-switch/index.tsx
+++ b/frontend/src/components/theme-switch/index.tsx
@@ -11,7 +11,7 @@ import {
 export const ThemeSwitch = Shade<Omit<ButtonProps, 'onclick'>>({
   customElementName: 'theme-switch',
   render: ({ props, injector, useState, useDisposable }) => {
-    const themeProvider = injector.getInstance(ThemeProviderService)
+    const themeProvider = injector.get(ThemeProviderService)
     const [theme, setTheme] = useState<'light' | 'dark'>(
       'theme',
       getCssVariable(themeProvider.theme.background.default) === defaultDarkTheme.background.default ? 'dark' : 'light',

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,5 @@
-/** ToDo: Main entry point */
-import { Injector } from '@furystack/inject'
+/** Main entry point */
+import { createInjector } from '@furystack/inject'
 import { getLogger, useLogging, VerboseConsoleLogger } from '@furystack/logging'
 import { createComponent, initializeShadeRoot } from '@furystack/shades'
 import { defaultDarkTheme, ThemeProviderService } from '@furystack/shades-common-components'
@@ -7,7 +7,7 @@ import { Layout } from './components/layout.js'
 import { environmentOptions } from './environment-options.js'
 import { SessionService } from './services/session.js'
 
-const shadeInjector = new Injector()
+const shadeInjector = createInjector()
 
 useLogging(shadeInjector, VerboseConsoleLogger)
 
@@ -16,11 +16,13 @@ void getLogger(shadeInjector).withScope('Startup').verbose({
   data: { environmentOptions },
 })
 
-shadeInjector.getInstance(SessionService)
+shadeInjector.get(SessionService)
+shadeInjector.get(ThemeProviderService).setAssignedTheme(defaultDarkTheme)
 
-shadeInjector.getInstance(ThemeProviderService).setAssignedTheme(defaultDarkTheme)
-
-const rootElement: HTMLDivElement = document.getElementById('root') as HTMLDivElement
+const rootElement = document.getElementById('root')
+if (!rootElement) {
+  throw new Error('Root element with id "root" not found.')
+}
 
 initializeShadeRoot({
   injector: shadeInjector,

--- a/frontend/src/pages/hello-world.tsx
+++ b/frontend/src/pages/hello-world.tsx
@@ -6,7 +6,7 @@ import { SessionService } from '../services/session.js'
 export const HelloWorld = Shade({
   customElementName: 'hello-world',
   render: ({ useObservable, useState, injector }) => {
-    const [currentUser] = useObservable('userName', injector.getInstance(SessionService).currentUser)
+    const [currentUser] = useObservable('userName', injector.get(SessionService).currentUser)
     const [authorizedResult, setAuthorizedResult] = useState<string>('authorizedResult', '')
     const [authorizedError, setAuthorizedError] = useState<string>('authorizedError', '')
 
@@ -14,7 +14,7 @@ export const HelloWorld = Shade({
       setAuthorizedResult('')
       setAuthorizedError('')
       try {
-        const apiClient = injector.getInstance(BoilerplateApiClient)
+        const apiClient = injector.get(BoilerplateApiClient)
         const { result } = await apiClient.call({ method: 'GET', action: '/testAuthorized' })
         setAuthorizedResult(`${result.message} (${result.timestamp})`)
       } catch (error) {

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -26,7 +26,7 @@ export const Login = Shade({
     padding: '16px',
   },
   render: ({ injector, useObservable }) => {
-    const sessionService = injector.getInstance(SessionService)
+    const sessionService = injector.get(SessionService)
     const [isOperationInProgress] = useObservable('isOperationInProgress', sessionService.isOperationInProgress)
     const [error] = useObservable('loginError', sessionService.loginError)
 

--- a/frontend/src/services/boilerplate-api-client.spec.ts
+++ b/frontend/src/services/boilerplate-api-client.spec.ts
@@ -1,0 +1,81 @@
+import { createInjector } from '@furystack/inject'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BoilerplateApiClient } from './boilerplate-api-client.js'
+
+const respondWithJson = (body: unknown, init: ResponseInit = {}): Response =>
+  new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    status: 200,
+    ...init,
+  })
+
+describe('BoilerplateApiClient', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('resolves to a singleton with the expected surface', async () => {
+    const injector = createInjector()
+
+    const client = injector.get(BoilerplateApiClient)
+
+    expect(typeof client.call).toBe('function')
+    expect(typeof client.login).toBe('function')
+    expect(typeof client.logout).toBe('function')
+    expect(typeof client.setTokens).toBe('function')
+    expect(client.isAuthenticated).toBe(false)
+
+    expect(injector.get(BoilerplateApiClient)).toBe(client)
+
+    await injector[Symbol.asyncDispose]()
+  })
+
+  it('login forwards credentials to the JWT login endpoint and stores the resulting tokens', async () => {
+    const accessToken = createFakeJwt({ exp: Math.floor(Date.now() / 1000) + 600 })
+    const refreshToken = createFakeJwt({ exp: Math.floor(Date.now() / 1000) + 7200 })
+    fetchMock.mockResolvedValueOnce(respondWithJson({ accessToken, refreshToken }))
+
+    const injector = createInjector()
+    const client = injector.get(BoilerplateApiClient)
+
+    await client.login({ username: 'alice', password: 'secret' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/jwt/login')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ username: 'alice', password: 'secret' })
+    expect(client.isAuthenticated).toBe(true)
+
+    await injector[Symbol.asyncDispose]()
+  })
+
+  it('setTokens activates the authenticated state without calling the network', async () => {
+    const injector = createInjector()
+    const client = injector.get(BoilerplateApiClient)
+
+    client.setTokens({
+      accessToken: createFakeJwt({ exp: Math.floor(Date.now() / 1000) + 600 }),
+      refreshToken: createFakeJwt({ exp: Math.floor(Date.now() / 1000) + 7200 }),
+    })
+
+    expect(client.isAuthenticated).toBe(true)
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    await injector[Symbol.asyncDispose]()
+  })
+})
+
+const createFakeJwt = (payload: Record<string, unknown>): string => {
+  const encode = (value: object): string =>
+    btoa(JSON.stringify(value)).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_')
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.signature`
+}

--- a/frontend/src/services/boilerplate-api-client.ts
+++ b/frontend/src/services/boilerplate-api-client.ts
@@ -1,44 +1,62 @@
 import { createJwtClient, createJwtTokenStore } from '@furystack/auth-jwt/client'
-import { Injectable } from '@furystack/inject'
+import { defineService, type Token } from '@furystack/inject'
 import { createClient } from '@furystack/rest-client-fetch'
 import type { AuthorizedApi, JwtApi } from 'common'
 import { environmentOptions } from '../environment-options.js'
 
 type AuthorizedApiCall = ReturnType<typeof createClient<AuthorizedApi>>
+type JwtTokenStore = ReturnType<typeof createJwtTokenStore>
 
-const jwtApiClient = createClient<JwtApi>({
-  endpointUrl: environmentOptions.serviceUrl,
-  requestInit: { credentials: 'include' },
-})
-
-const tokenStore = createJwtTokenStore({
-  refreshThresholdSeconds: 10,
-  login: async (credentials) => {
-    const { result } = await jwtApiClient({ method: 'POST', action: '/jwt/login', body: credentials })
-    return result
-  },
-  refresh: async (refreshToken) => {
-    const { result } = await jwtApiClient({ method: 'POST', action: '/jwt/refresh', body: { refreshToken } })
-    return result
-  },
-  logout: async (refreshToken) => {
-    await jwtApiClient({ method: 'POST', action: '/jwt/logout', body: { refreshToken } })
-  },
-})
-
-const authorizedClient = createJwtClient<AuthorizedApi>({
-  endpointUrl: environmentOptions.serviceUrl,
-  tokenStore,
-})
-
-@Injectable({ lifetime: 'singleton' })
-export class BoilerplateApiClient {
-  public call: AuthorizedApiCall = authorizedClient.call as AuthorizedApiCall
-  public login = tokenStore.login
-  public logout = tokenStore.logout
-  public setTokens = tokenStore.setTokens
-
-  public get isAuthenticated(): boolean {
-    return tokenStore.isAuthenticated
-  }
+/**
+ * Browser-side facade over the JWT-aware REST client. Holds the shared
+ * {@link createJwtTokenStore} so login/logout/refresh state is consistent
+ * across every consumer.
+ */
+export interface BoilerplateApiClient {
+  call: AuthorizedApiCall
+  login: JwtTokenStore['login']
+  logout: JwtTokenStore['logout']
+  setTokens: JwtTokenStore['setTokens']
+  readonly isAuthenticated: boolean
 }
+
+export const BoilerplateApiClient: Token<BoilerplateApiClient, 'singleton'> = defineService({
+  name: 'app/BoilerplateApiClient',
+  lifetime: 'singleton',
+  factory: () => {
+    const jwtApiClient = createClient<JwtApi>({
+      endpointUrl: environmentOptions.serviceUrl,
+      requestInit: { credentials: 'include' },
+    })
+
+    const tokenStore = createJwtTokenStore({
+      refreshThresholdSeconds: 10,
+      login: async (credentials) => {
+        const { result } = await jwtApiClient({ method: 'POST', action: '/jwt/login', body: credentials })
+        return result
+      },
+      refresh: async (refreshToken) => {
+        const { result } = await jwtApiClient({ method: 'POST', action: '/jwt/refresh', body: { refreshToken } })
+        return result
+      },
+      logout: async (refreshToken) => {
+        await jwtApiClient({ method: 'POST', action: '/jwt/logout', body: { refreshToken } })
+      },
+    })
+
+    const authorizedClient = createJwtClient<AuthorizedApi>({
+      endpointUrl: environmentOptions.serviceUrl,
+      tokenStore,
+    })
+
+    return {
+      call: authorizedClient.call as AuthorizedApiCall,
+      login: tokenStore.login,
+      logout: tokenStore.logout,
+      setTokens: tokenStore.setTokens,
+      get isAuthenticated() {
+        return tokenStore.isAuthenticated
+      },
+    }
+  },
+})

--- a/frontend/src/services/session.spec.ts
+++ b/frontend/src/services/session.spec.ts
@@ -1,0 +1,200 @@
+import { createInjector, type Injector } from '@furystack/inject'
+import { NotyService } from '@furystack/shades-common-components'
+import type { User } from 'common'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { BoilerplateApiClient } from './boilerplate-api-client.js'
+import { SessionService } from './session.js'
+
+type MockApiClient = {
+  call: ReturnType<typeof vi.fn>
+  login: ReturnType<typeof vi.fn>
+  logout: ReturnType<typeof vi.fn>
+  setTokens: ReturnType<typeof vi.fn>
+  isAuthenticated: boolean
+}
+
+const createMockApiClient = (overrides: Partial<MockApiClient> = {}): MockApiClient => ({
+  call: vi.fn(),
+  login: vi.fn().mockResolvedValue(undefined),
+  logout: vi.fn().mockResolvedValue(undefined),
+  setTokens: vi.fn(),
+  isAuthenticated: false,
+  ...overrides,
+})
+
+const createMockNotyService = () => {
+  const emit = vi.fn()
+  return { service: { emit } as unknown as NotyService, emit }
+}
+
+const flushMicrotasks = async (): Promise<void> => {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve()
+  }
+}
+
+const setupInjector = (api: MockApiClient, noty: NotyService): Injector => {
+  const injector = createInjector()
+  injector.bind(BoilerplateApiClient, () => api as unknown as BoilerplateApiClient)
+  injector.bind(NotyService, () => noty)
+  return injector
+}
+
+describe('SessionService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('init (auto-invoked from factory)', () => {
+    it('moves to "unauthenticated" when the api reports no active session', async () => {
+      const api = createMockApiClient({ isAuthenticated: false })
+      const { service: notys } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+
+      expect(session.state.getValue()).toBe('unauthenticated')
+      expect(session.currentUser.getValue()).toBeNull()
+      expect(api.call).not.toHaveBeenCalled()
+
+      await injector[Symbol.asyncDispose]()
+    })
+
+    it('fetches the current user and moves to "authenticated" when the api has a session', async () => {
+      const user: User = { username: 'alice', roles: ['admin'] }
+      const api = createMockApiClient({
+        isAuthenticated: true,
+        call: vi.fn().mockResolvedValue({ result: user }),
+      })
+      const { service: notys } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+
+      expect(session.state.getValue()).toBe('authenticated')
+      expect(session.currentUser.getValue()).toEqual(user)
+      expect(api.call).toHaveBeenCalledWith({ method: 'GET', action: '/currentUser' })
+
+      await injector[Symbol.asyncDispose]()
+    })
+
+    it('moves to "offline" when the current-user fetch fails', async () => {
+      const api = createMockApiClient({
+        isAuthenticated: true,
+        call: vi.fn().mockRejectedValue(new Error('network down')),
+      })
+      const { service: notys } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+
+      expect(session.state.getValue()).toBe('offline')
+
+      await injector[Symbol.asyncDispose]()
+    })
+  })
+
+  describe('login', () => {
+    it('moves to "authenticated" and fires a success noty on a successful login', async () => {
+      const user: User = { username: 'alice', roles: [] }
+      const api = createMockApiClient({
+        isAuthenticated: false,
+        call: vi.fn().mockResolvedValue({ result: user }),
+      })
+      const { service: notys, emit } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+
+      await session.login('alice', 'pw')
+
+      expect(api.login).toHaveBeenCalledWith({ username: 'alice', password: 'pw' })
+      expect(session.state.getValue()).toBe('authenticated')
+      expect(session.currentUser.getValue()).toEqual(user)
+      expect(emit).toHaveBeenCalledWith('onNotyAdded', expect.objectContaining({ type: 'success' }))
+
+      await injector[Symbol.asyncDispose]()
+    })
+
+    it('records the error message and fires a warning noty on a failed login', async () => {
+      const api = createMockApiClient({
+        login: vi.fn().mockRejectedValue(new Error('bad credentials')),
+      })
+      const { service: notys, emit } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+
+      await session.login('alice', 'wrong')
+
+      expect(session.loginError.getValue()).toBe('bad credentials')
+      expect(session.state.getValue()).not.toBe('authenticated')
+      expect(emit).toHaveBeenCalledWith('onNotyAdded', expect.objectContaining({ type: 'warning' }))
+
+      await injector[Symbol.asyncDispose]()
+    })
+  })
+
+  describe('logout', () => {
+    it('clears the user, moves to "unauthenticated" and fires an info noty', async () => {
+      const user: User = { username: 'alice', roles: [] }
+      const api = createMockApiClient({
+        isAuthenticated: true,
+        call: vi.fn().mockResolvedValue({ result: user }),
+      })
+      const { service: notys, emit } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+      expect(session.state.getValue()).toBe('authenticated')
+
+      await session.logout()
+
+      expect(api.logout).toHaveBeenCalledTimes(1)
+      expect(session.currentUser.getValue()).toBeNull()
+      expect(session.state.getValue()).toBe('unauthenticated')
+      expect(emit).toHaveBeenCalledWith('onNotyAdded', expect.objectContaining({ type: 'info' }))
+
+      await injector[Symbol.asyncDispose]()
+    })
+  })
+
+  describe('isAuthorized', () => {
+    it('returns true when the current user has every requested role', async () => {
+      const api = createMockApiClient({
+        isAuthenticated: true,
+        call: vi.fn().mockResolvedValue({ result: { username: 'a', roles: ['admin', 'editor'] } satisfies User }),
+      })
+      const { service: notys } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+
+      expect(await session.isAuthorized('admin')).toBe(true)
+      expect(await session.isAuthorized('admin', 'editor')).toBe(true)
+      expect(await session.isAuthorized('admin', 'owner')).toBe(false)
+
+      await injector[Symbol.asyncDispose]()
+    })
+
+    it('returns false when no user is signed in', async () => {
+      const api = createMockApiClient({ isAuthenticated: false })
+      const { service: notys } = createMockNotyService()
+      const injector = setupInjector(api, notys)
+
+      const session = injector.get(SessionService)
+      await flushMicrotasks()
+
+      expect(await session.isAuthorized('admin')).toBe(false)
+
+      await injector[Symbol.asyncDispose]()
+    })
+  })
+})

--- a/frontend/src/services/session.ts
+++ b/frontend/src/services/session.ts
@@ -1,5 +1,5 @@
 import type { IdentityContext } from '@furystack/core'
-import { Injectable, Injected } from '@furystack/inject'
+import { defineService, type Token } from '@furystack/inject'
 import { NotyService } from '@furystack/shades-common-components'
 import { ObservableValue, usingAsync } from '@furystack/utils'
 import type { User } from 'common'
@@ -7,114 +7,135 @@ import { BoilerplateApiClient } from './boilerplate-api-client.js'
 
 export type SessionState = 'initializing' | 'offline' | 'unauthenticated' | 'authenticated'
 
-@Injectable({ lifetime: 'singleton' })
-export class SessionService implements IdentityContext, Disposable {
-  private readonly operation = (): Disposable => {
-    this.isOperationInProgress.setValue(true)
-    return { [Symbol.dispose]: () => this.isOperationInProgress.setValue(false) }
-  }
+export interface SessionService extends IdentityContext {
+  readonly state: ObservableValue<SessionState>
+  readonly currentUser: ObservableValue<Omit<User, 'password'> | null>
+  readonly isOperationInProgress: ObservableValue<boolean>
+  readonly loginError: ObservableValue<string>
+  init(): Promise<void>
+  login(username: string, password: string): Promise<void>
+  logout(): Promise<void>
+}
 
-  public state = new ObservableValue<SessionState>('initializing')
-  public currentUser = new ObservableValue<Omit<User, 'password'> | null>(null)
+export const SessionService: Token<SessionService, 'singleton'> = defineService({
+  name: 'app/SessionService',
+  lifetime: 'singleton',
+  factory: ({ inject, onDispose }) => {
+    const api = inject(BoilerplateApiClient)
+    const notys = inject(NotyService)
 
-  public isOperationInProgress = new ObservableValue(true)
+    const state = new ObservableValue<SessionState>('initializing')
+    const currentUser = new ObservableValue<Omit<User, 'password'> | null>(null)
+    const isOperationInProgress = new ObservableValue(true)
+    const loginError = new ObservableValue('')
 
-  public loginError = new ObservableValue('')
+    const operation = (): Disposable => {
+      isOperationInProgress.setValue(true)
+      return { [Symbol.dispose]: () => isOperationInProgress.setValue(false) }
+    }
 
-  private isInitialized = false
-
-  public async init(): Promise<void> {
-    await usingAsync(this.operation(), async () => {
-      if (!this.isInitialized) {
-        this.isInitialized = true
+    let isInitialized = false
+    const init = async (): Promise<void> => {
+      await usingAsync(operation(), async () => {
+        if (isInitialized) return
+        isInitialized = true
         try {
-          if (this.api.isAuthenticated) {
-            const { result: usr } = await this.api.call({ method: 'GET', action: '/currentUser' })
-            this.currentUser.setValue(usr)
-            this.state.setValue('authenticated')
+          if (api.isAuthenticated) {
+            const { result: usr } = await api.call({ method: 'GET', action: '/currentUser' })
+            currentUser.setValue(usr)
+            state.setValue('authenticated')
           } else {
-            this.state.setValue('unauthenticated')
+            state.setValue('unauthenticated')
           }
-        } catch (error) {
-          this.state.setValue('offline')
+        } catch {
+          state.setValue('offline')
         }
-      }
-    })
-  }
+      })
+    }
 
-  public async login(username: string, password: string): Promise<void> {
-    await usingAsync(this.operation(), async () => {
-      try {
-        await this.api.login({ username, password })
-        const { result: usr } = await this.api.call({ method: 'GET', action: '/currentUser' })
-        this.currentUser.setValue(usr)
-        this.state.setValue('authenticated')
-        this.notys.emit('onNotyAdded', {
-          body: 'Welcome back ;)',
-          title: 'You have been logged in',
-          type: 'success',
+    const login = async (username: string, password: string): Promise<void> => {
+      await usingAsync(operation(), async () => {
+        try {
+          await api.login({ username, password })
+          const { result: usr } = await api.call({ method: 'GET', action: '/currentUser' })
+          currentUser.setValue(usr)
+          state.setValue('authenticated')
+          notys.emit('onNotyAdded', {
+            body: 'Welcome back ;)',
+            title: 'You have been logged in',
+            type: 'success',
+          })
+        } catch (error) {
+          loginError.setValue(error instanceof Error ? error.message : '')
+          notys.emit('onNotyAdded', {
+            body: 'Please check your credentials',
+            title: 'Login failed',
+            type: 'warning',
+          })
+        }
+      })
+    }
+
+    const logout = async (): Promise<void> => {
+      await usingAsync(operation(), async () => {
+        await api.logout()
+        currentUser.setValue(null)
+        state.setValue('unauthenticated')
+        notys.emit('onNotyAdded', {
+          body: 'Come back soon...',
+          title: 'You have been logged out',
+          type: 'info',
         })
-      } catch (error) {
-        this.loginError.setValue(error instanceof Error ? error.message : '')
-        this.notys.emit('onNotyAdded', {
-          body: 'Please check your credentials',
-          title: 'Login failed',
+      })
+    }
+
+    const isAuthenticated = async (): Promise<boolean> => state.getValue() === 'authenticated'
+
+    const getCurrentUserOrThrow = <TUser extends User>(): TUser => {
+      const user = currentUser.getValue()
+      if (!user) {
+        notys.emit('onNotyAdded', {
+          body: ':(((',
+          title: 'No User available',
           type: 'warning',
         })
+        throw new Error('No user available')
       }
-    })
-  }
-
-  public async logout(): Promise<void> {
-    return await usingAsync(this.operation(), async () => {
-      await this.api.logout()
-      this.currentUser.setValue(null)
-      this.state.setValue('unauthenticated')
-      this.notys.emit('onNotyAdded', {
-        body: 'Come back soon...',
-        title: 'You have been logged out',
-        type: 'info',
-      })
-    })
-  }
-
-  public async isAuthenticated(): Promise<boolean> {
-    return this.state.getValue() === 'authenticated'
-  }
-
-  public async isAuthorized(...roles: string[]): Promise<boolean> {
-    const currentUser = await this.getCurrentUser()
-    for (const role of roles) {
-      if (!currentUser || !currentUser.roles.some((c) => c === role)) {
-        return false
-      }
+      return user as unknown as TUser
     }
-    return true
-  }
 
-  public async getCurrentUser<TUser extends User>(): Promise<TUser> {
-    const currentUser = this.currentUser.getValue()
-    if (!currentUser) {
-      this.notys.emit('onNotyAdded', {
-        body: ':(((',
-        title: 'No User available',
-        type: 'warning',
-      })
-      throw Error('No user available')
+    const isAuthorized = async (...roles: string[]): Promise<boolean> => {
+      const user = currentUser.getValue()
+      if (!user) return false
+      return roles.every((role) => user.roles.includes(role))
     }
-    return currentUser as unknown as TUser
-  }
 
-  @Injected(BoilerplateApiClient)
-  declare private api: BoilerplateApiClient
+    const getCurrentUser = async <TUser extends User>(): Promise<TUser> => getCurrentUserOrThrow<TUser>()
 
-  @Injected(NotyService)
-  declare private readonly notys: NotyService
+    onDispose(() => {
+      // eslint-disable-next-line furystack/prefer-using-wrapper -- Disposal is deferred to the injector's onDispose hook.
+      state[Symbol.dispose]()
+      // eslint-disable-next-line furystack/prefer-using-wrapper -- Disposal is deferred to the injector's onDispose hook.
+      currentUser[Symbol.dispose]()
+      // eslint-disable-next-line furystack/prefer-using-wrapper -- Disposal is deferred to the injector's onDispose hook.
+      isOperationInProgress[Symbol.dispose]()
+      // eslint-disable-next-line furystack/prefer-using-wrapper -- Disposal is deferred to the injector's onDispose hook.
+      loginError[Symbol.dispose]()
+    })
 
-  public [Symbol.dispose](): void {
-    this.state[Symbol.dispose]()
-    this.currentUser[Symbol.dispose]()
-    this.isOperationInProgress[Symbol.dispose]()
-    this.loginError[Symbol.dispose]()
-  }
-}
+    void init()
+
+    return {
+      state,
+      currentUser,
+      isOperationInProgress,
+      loginError,
+      init,
+      login,
+      logout,
+      isAuthenticated,
+      isAuthorized,
+      getCurrentUser,
+    }
+  },
+})

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,59 +1,16 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    /* Basic Options */
-    "target": "ES2022" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    "module": "NodeNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    "outDir": "./dist/js",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "react",
     "jsxFactory": "createComponent",
     "jsxFragmentFactory": "createFragment",
     "lib": ["ES2022", "DOM", "esnext.disposable"],
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
-    "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
-    "sourceMap": true /* Generates corresponding '.map' file. */,
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist/js" /* Redirect output structure to the directory. */,
-    // "rootDir": "./", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    "composite": true /* Enable project compilation */,
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true, /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-    /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
-    "strictNullChecks": true /* Enable strict null checks. */,
-    "strictFunctionTypes": true /* Enable strict checking of function types. */,
-    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
-    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
-    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
-    /* Additional Checks */
-    "noUnusedLocals": true /* Report errors on unused locals. */,
-    "noUnusedParameters": true /* Report errors on unused parameters. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-    /* Module Resolution Options */
-    "moduleResolution": "NodeNext" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    // "baseUrl": "./", /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    // "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true, /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true, /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-    /* Experimental Options */
-    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
-    "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
-    "pretty": true,
-    "skipLibCheck": true
+    "types": [],
+    "pretty": true
   },
   "include": ["src"],
   "references": [{ "path": "../common" }]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-jsdoc": "^62.9.0",
     "eslint-plugin-playwright": "^2.10.2",
     "eslint-plugin-prettier": "^5.5.5",
+    "happy-dom": "^20.9.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "type": "module",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@furystack/eslint-plugin": "^2.2.0",
+    "@furystack/eslint-plugin": "^3.0.0",
     "@furystack/yarn-plugin-changelog": "^1.0.10",
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",

--- a/service/package.json
+++ b/service/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "start": "yarn node ./dist/service.js",
-    "seed": "yarn node ./dist/seed.js",
+    "seed": "yarn node ./dist/bin/seed.js",
     "clean": "rimraf dist && rimraf tsconfig.tsbuildinfo",
     "build": "tsc -b"
   },

--- a/service/package.json
+++ b/service/package.json
@@ -17,14 +17,14 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@furystack/auth-jwt": "^3.0.0",
-    "@furystack/core": "^16.0.4",
-    "@furystack/filesystem-store": "^7.1.7",
-    "@furystack/inject": "^12.0.36",
-    "@furystack/logging": "^8.1.5",
-    "@furystack/repository": "^10.1.11",
-    "@furystack/rest-service": "^13.0.0",
-    "@furystack/security": "^7.0.9",
+    "@furystack/auth-jwt": "^4.0.0",
+    "@furystack/core": "^17.0.0",
+    "@furystack/filesystem-store": "^8.0.0",
+    "@furystack/inject": "^13.0.0",
+    "@furystack/logging": "^9.0.0",
+    "@furystack/repository": "^11.0.0",
+    "@furystack/rest-service": "^14.0.0",
+    "@furystack/security": "^8.0.0",
     "common": "workspace:^"
   }
 }

--- a/service/src/bin/seed.ts
+++ b/service/src/bin/seed.ts
@@ -1,0 +1,7 @@
+import { injector } from '../root-injector.js'
+import { seed } from '../seed.js'
+import { setupStore } from '../setup-store.js'
+
+setupStore(injector)
+await seed(injector)
+await injector[Symbol.asyncDispose]()

--- a/service/src/config.spec.ts
+++ b/service/src/config.spec.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest'
-
-describe('Config tests', () => {
-  it('Should match the snapshot', () => {
-    expect(true)
-  })
-})

--- a/service/src/root-injector.ts
+++ b/service/src/root-injector.ts
@@ -1,5 +1,5 @@
-import { Injector } from '@furystack/inject'
+import { createInjector } from '@furystack/inject'
 import { useLogging, VerboseConsoleLogger } from '@furystack/logging'
 
-export const injector = new Injector()
+export const injector = createInjector()
 useLogging(injector, VerboseConsoleLogger)

--- a/service/src/seed.spec.ts
+++ b/service/src/seed.spec.ts
@@ -1,0 +1,57 @@
+import { createInjector } from '@furystack/inject'
+import type { DataSet } from '@furystack/repository'
+import { describe, expect, it, vi } from 'vitest'
+import { getOrCreate } from './seed.js'
+
+type Item = { id: string; name: string }
+
+const newDataSetMock = (findResult: Item[], createdEntities: Item[] = []) =>
+  ({
+    find: vi.fn().mockResolvedValue(findResult),
+    add: vi.fn().mockResolvedValue({ created: createdEntities }),
+  }) as unknown as DataSet<Item, 'id'>
+
+describe('getOrCreate', () => {
+  it('returns the existing entity when find yields exactly one result', async () => {
+    const existing: Item = { id: '1', name: 'existing' }
+    const dataSet = newDataSetMock([existing])
+    const injector = createInjector()
+
+    const result = await getOrCreate({ filter: { id: { $eq: '1' } } }, { id: '1', name: 'existing' }, dataSet, injector)
+
+    expect(result).toBe(existing)
+    expect(dataSet.find).toHaveBeenCalledTimes(1)
+    expect(dataSet.add).not.toHaveBeenCalled()
+  })
+
+  it('inserts the supplied instance when find yields no result and returns the created entity', async () => {
+    const created: Item = { id: '2', name: 'created' }
+    const dataSet = newDataSetMock([], [created])
+    const injector = createInjector()
+
+    const result = await getOrCreate({ filter: { id: { $eq: '2' } } }, { id: '2', name: 'created' }, dataSet, injector)
+
+    expect(result).toBe(created)
+    expect(dataSet.add).toHaveBeenCalledTimes(1)
+    expect(dataSet.add).toHaveBeenCalledWith(injector, { id: '2', name: 'created' })
+  })
+
+  it('warns and returns the first match when the filter is ambiguous', async () => {
+    const matches: Item[] = [
+      { id: '3a', name: 'first' },
+      { id: '3b', name: 'second' },
+    ]
+    const dataSet = newDataSetMock(matches)
+    const injector = createInjector()
+
+    const result = await getOrCreate(
+      { filter: { name: { $eq: 'first' } } },
+      { id: '3', name: 'first' },
+      dataSet,
+      injector,
+    )
+
+    expect(result).toBe(matches[0])
+    expect(dataSet.add).not.toHaveBeenCalled()
+  })
+})

--- a/service/src/seed.ts
+++ b/service/src/seed.ts
@@ -4,21 +4,16 @@ import type { Injector } from '@furystack/inject'
 import { getLogger } from '@furystack/logging'
 import type { DataSet } from '@furystack/repository'
 import { getDataSetFor } from '@furystack/repository'
-import { PasswordAuthenticator, PasswordCredential } from '@furystack/security'
+import { PasswordAuthenticator, PasswordCredentialDataSet } from '@furystack/security'
 import { usingAsync } from '@furystack/utils'
-import { User } from 'common'
 import { injector } from './root-injector.js'
-import { setupStore } from './setup-store.js'
+import { AuthorizedUserDataSet, setupStore } from './setup-store.js'
 
 /**
- * gets an existing instance if exists or create and return if not. Throws error on multiple result
- * @param filter The filter term
- * @param instance The instance to be created if there is no instance present
- * @param dataSet The DataSet to use
- * @param i The Injector instance
- * @returns The retrieved or created object
+ * Returns the existing entity matching `filter` or creates `instance`
+ * when none is found. Logs a warning when the filter is ambiguous.
  */
-export const getOrCreate = async <T, TKey extends keyof T>(
+const getOrCreate = async <T, TKey extends keyof T>(
   filter: FindOptions<T, Array<keyof T>>,
   instance: WithOptionalId<T, TKey>,
   dataSet: DataSet<T, TKey>,
@@ -28,46 +23,35 @@ export const getOrCreate = async <T, TKey extends keyof T>(
   const logger = getLogger(i).withScope('seeder')
   if (result.length === 1) {
     return result[0]
-  } else if (result.length === 0) {
-    await logger.verbose({
-      message: `Entity not exists, adding: '${JSON.stringify(filter)}'`,
-    })
+  }
+  if (result.length === 0) {
+    await logger.verbose({ message: `Entity not exists, adding: '${JSON.stringify(filter)}'` })
     const createResult = await dataSet.add(i, instance)
     return createResult.created[0]
-  } else {
-    const message = `Seed filter contains '${result.length}' results for ${JSON.stringify(filter)}`
-    await logger.warning({ message })
-    return result[0]
   }
+  await logger.warning({ message: `Seed filter contains '${result.length}' results for ${JSON.stringify(filter)}` })
+  return result[0]
 }
 
 /**
- * Seeds the databases with predefined values
- * @param i The injector instance
+ * Seeds the persistence layer with a default test user / credential pair.
  */
 export const seed = async (i: Injector): Promise<void> => {
   await usingAsync(useSystemIdentityContext({ injector: i, username: 'seeder' }), async (systemInjector) => {
     const logger = getLogger(systemInjector).withScope('seeder')
     await logger.verbose({ message: 'Seeding data...' })
-    const userDataSet = getDataSetFor(systemInjector, User, 'username')
-    const pwcDataSet = getDataSetFor(systemInjector, PasswordCredential, 'userName')
-    const cred = await systemInjector.getInstance(PasswordAuthenticator).hasher.createCredential('testuser', 'password')
+
+    const userDataSet = getDataSetFor(systemInjector, AuthorizedUserDataSet)
+    const pwcDataSet = getDataSetFor(systemInjector, PasswordCredentialDataSet)
+    const credential = await systemInjector.get(PasswordAuthenticator).hasher.createCredential('testuser', 'password')
+
     await logger.verbose({ message: 'Saving credential...' })
-    await getOrCreate(
-      {
-        filter: { userName: { $eq: 'testuser' } },
-      },
-      cred,
-      pwcDataSet,
-      systemInjector,
-    )
+    await getOrCreate({ filter: { userName: { $eq: 'testuser' } } }, credential, pwcDataSet, systemInjector)
+
     await logger.verbose({ message: 'Saving User...' })
     await getOrCreate(
       { filter: { username: { $eq: 'testuser' } } },
-      {
-        username: 'testuser',
-        roles: [],
-      },
+      { username: 'testuser', roles: [] },
       userDataSet,
       systemInjector,
     )

--- a/service/src/seed.ts
+++ b/service/src/seed.ts
@@ -6,14 +6,13 @@ import type { DataSet } from '@furystack/repository'
 import { getDataSetFor } from '@furystack/repository'
 import { PasswordAuthenticator, PasswordCredentialDataSet } from '@furystack/security'
 import { usingAsync } from '@furystack/utils'
-import { injector } from './root-injector.js'
-import { AuthorizedUserDataSet, setupStore } from './setup-store.js'
+import { AuthorizedUserDataSet } from './setup-store.js'
 
 /**
  * Returns the existing entity matching `filter` or creates `instance`
  * when none is found. Logs a warning when the filter is ambiguous.
  */
-const getOrCreate = async <T, TKey extends keyof T>(
+export const getOrCreate = async <T, TKey extends keyof T>(
   filter: FindOptions<T, Array<keyof T>>,
   instance: WithOptionalId<T, TKey>,
   dataSet: DataSet<T, TKey>,
@@ -59,7 +58,3 @@ export const seed = async (i: Injector): Promise<void> => {
     await logger.verbose({ message: 'Seeding data completed.' })
   })
 }
-
-setupStore(injector)
-await seed(injector)
-await injector[Symbol.asyncDispose]()

--- a/service/src/setup-store.spec.ts
+++ b/service/src/setup-store.spec.ts
@@ -1,0 +1,83 @@
+import { RefreshTokenStore } from '@furystack/auth-jwt'
+import { JwtAuthenticationSettings } from '@furystack/auth-jwt'
+import { createInjector } from '@furystack/inject'
+import { HttpAuthenticationSettings, SessionStore, UserStore } from '@furystack/rest-service'
+import { PasswordCredentialStore, PasswordResetTokenStore } from '@furystack/security'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AuthorizedUserDataSet, requireJwtSecret, setupStore } from './setup-store.js'
+
+describe('requireJwtSecret', () => {
+  const longSecret = 'a'.repeat(32)
+  const shortSecret = 'too-short'
+
+  it('returns the env value when it is at least 32 bytes long', () => {
+    expect(requireJwtSecret({ JWT_SECRET: longSecret })).toBe(longSecret)
+  })
+
+  it('falls back to the dev secret when the env var is missing in non-production', () => {
+    expect(requireJwtSecret({ NODE_ENV: 'development' })).toBe('change-me-to-a-secure-32-byte-secret!')
+  })
+
+  it('falls back to the dev secret when the env var is too short in non-production', () => {
+    expect(requireJwtSecret({ JWT_SECRET: shortSecret, NODE_ENV: 'test' })).toBe(
+      'change-me-to-a-secure-32-byte-secret!',
+    )
+  })
+
+  it('throws when the secret is missing in production', () => {
+    expect(() => requireJwtSecret({ NODE_ENV: 'production' })).toThrow(/JWT_SECRET must be set/)
+  })
+
+  it('throws when the secret is too short in production', () => {
+    expect(() => requireJwtSecret({ JWT_SECRET: shortSecret, NODE_ENV: 'production' })).toThrow(
+      /JWT_SECRET must be set/,
+    )
+  })
+
+  it('measures byte length, not character count, for multi-byte characters', () => {
+    // 11 emojis at 4 bytes each = 44 UTF-8 bytes, well above the 32 byte floor.
+    const emojiSecret = '🔐'.repeat(11)
+    expect(requireJwtSecret({ JWT_SECRET: emojiSecret })).toBe(emojiSecret)
+  })
+
+  it('rejects 31 byte secrets in production (boundary)', () => {
+    expect(() => requireJwtSecret({ JWT_SECRET: 'a'.repeat(31), NODE_ENV: 'production' })).toThrow()
+  })
+
+  it('accepts 32 byte secrets (boundary)', () => {
+    expect(requireJwtSecret({ JWT_SECRET: 'a'.repeat(32), NODE_ENV: 'production' })).toBe('a'.repeat(32))
+  })
+})
+
+describe('setupStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('binds every framework store token, password policy, http auth and jwt auth', async () => {
+    const injector = createInjector()
+    const bindSpy = vi.spyOn(injector, 'bind')
+
+    setupStore(injector)
+
+    const boundTokens = bindSpy.mock.calls.map(([token]) => token)
+    expect(boundTokens).toContain(UserStore)
+    expect(boundTokens).toContain(SessionStore)
+    expect(boundTokens).toContain(PasswordCredentialStore)
+    expect(boundTokens).toContain(PasswordResetTokenStore)
+    expect(boundTokens).toContain(RefreshTokenStore)
+
+    // useHttpAuthentication / useJwtAuthentication rebind their settings tokens.
+    expect(boundTokens).toContain(HttpAuthenticationSettings)
+    expect(boundTokens).toContain(JwtAuthenticationSettings)
+
+    const httpSettings = injector.get(HttpAuthenticationSettings)
+    expect(httpSettings.userDataSet).toBe(AuthorizedUserDataSet)
+
+    await injector[Symbol.asyncDispose]()
+  })
+})

--- a/service/src/setup-store.ts
+++ b/service/src/setup-store.ts
@@ -64,12 +64,19 @@ export const AuthorizedUserDataSet: DataSetToken<User, 'username'> = defineDataS
   settings: authorizedDataSet,
 })
 
-const requireJwtSecret = (): string => {
-  const secret = process.env.JWT_SECRET
-  if (secret && secret.length >= 32) {
+/**
+ * Resolves the JWT signing secret from the environment.
+ *
+ * - Returns `process.env.JWT_SECRET` when it is at least 32 bytes long.
+ * - Throws when `NODE_ENV === 'production'` and the env var is missing or too short.
+ * - Falls back to a fixed development secret in any other case.
+ */
+export const requireJwtSecret = (env: NodeJS.ProcessEnv = process.env): string => {
+  const secret = env.JWT_SECRET
+  if (secret && Buffer.byteLength(secret, 'utf8') >= 32) {
     return secret
   }
-  if (process.env.NODE_ENV === 'production') {
+  if (env.NODE_ENV === 'production') {
     throw new Error('JWT_SECRET must be set to a 32+ byte value in production.')
   }
   return 'change-me-to-a-secure-32-byte-secret!'

--- a/service/src/setup-store.ts
+++ b/service/src/setup-store.ts
@@ -1,46 +1,95 @@
-import { RefreshToken, useJwtAuthentication } from '@furystack/auth-jwt'
-import { addStore, InMemoryStore } from '@furystack/core'
-import { FileSystemStore } from '@furystack/filesystem-store'
+import { RefreshToken, RefreshTokenStore, useJwtAuthentication } from '@furystack/auth-jwt'
+import { defineStore, InMemoryStore } from '@furystack/core'
+import { defineFileSystemStore } from '@furystack/filesystem-store'
 import type { Injector } from '@furystack/inject'
-import { getRepository } from '@furystack/repository'
-import { DefaultSession, useHttpAuthentication } from '@furystack/rest-service'
-import { PasswordCredential, PasswordResetToken, usePasswordPolicy } from '@furystack/security'
+import { defineDataSet, type DataSetToken } from '@furystack/repository'
+import { DefaultSession, SessionStore, useHttpAuthentication, UserStore } from '@furystack/rest-service'
+import {
+  PasswordCredential,
+  PasswordCredentialStore,
+  PasswordResetToken,
+  PasswordResetTokenStore,
+  usePasswordPolicy,
+} from '@furystack/security'
 import { User } from 'common'
 import { join } from 'path'
 import { authorizedDataSet } from './authorization/authorized-only.js'
 
-export const setupStore = (injector: Injector): void => {
-  addStore(
-    injector,
-    new FileSystemStore({
-      model: User,
-      primaryKey: 'username',
-      tickMs: 30_000,
-      fileName: join(process.cwd(), 'users.json'),
-    }),
-  )
-    .addStore(new InMemoryStore({ model: DefaultSession, primaryKey: 'sessionId' }))
-    .addStore(
-      new FileSystemStore({
-        model: PasswordCredential,
-        primaryKey: 'userName',
-        fileName: join(process.cwd(), '..', '..', 'pwc.json'),
-      }),
-    )
-    .addStore(new InMemoryStore({ model: PasswordResetToken, primaryKey: 'token' }))
-    .addStore(new InMemoryStore({ model: RefreshToken, primaryKey: 'token' }))
+const usersFile = join(process.cwd(), 'users.json')
+const passwordCredentialsFile = join(process.cwd(), '..', '..', 'pwc.json')
 
-  getRepository(injector)
-    .createDataSet(User, 'username', { ...authorizedDataSet })
-    .createDataSet(DefaultSession, 'sessionId')
-    .createDataSet(PasswordCredential, 'userName')
-    .createDataSet(PasswordResetToken, 'token')
-    .createDataSet(RefreshToken, 'token')
+const UsersFileStore = defineFileSystemStore({
+  name: 'app/UsersFileStore',
+  model: User,
+  primaryKey: 'username',
+  fileName: usersFile,
+  tickMs: 30_000,
+})
+
+const PasswordCredentialsFileStore = defineFileSystemStore({
+  name: 'app/PasswordCredentialsFileStore',
+  model: PasswordCredential,
+  primaryKey: 'userName',
+  fileName: passwordCredentialsFile,
+})
+
+const SessionsMemoryStore = defineStore({
+  name: 'app/SessionsMemoryStore',
+  model: DefaultSession,
+  primaryKey: 'sessionId',
+  factory: () => new InMemoryStore({ model: DefaultSession, primaryKey: 'sessionId' }),
+})
+
+const PasswordResetTokensMemoryStore = defineStore({
+  name: 'app/PasswordResetTokensMemoryStore',
+  model: PasswordResetToken,
+  primaryKey: 'token',
+  factory: () => new InMemoryStore({ model: PasswordResetToken, primaryKey: 'token' }),
+})
+
+const RefreshTokensMemoryStore = defineStore({
+  name: 'app/RefreshTokensMemoryStore',
+  model: RefreshToken,
+  primaryKey: 'token',
+  factory: () => new InMemoryStore({ model: RefreshToken, primaryKey: 'token' }),
+})
+
+/**
+ * Authorization-aware {@link User} dataset, exported so the REST API
+ * registers the same instance through {@link useHttpAuthentication}.
+ */
+export const AuthorizedUserDataSet: DataSetToken<User, 'username'> = defineDataSet({
+  name: 'app/AuthorizedUserDataSet',
+  store: UserStore,
+  settings: authorizedDataSet,
+})
+
+const requireJwtSecret = (): string => {
+  const secret = process.env.JWT_SECRET
+  if (secret && secret.length >= 32) {
+    return secret
+  }
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('JWT_SECRET must be set to a 32+ byte value in production.')
+  }
+  return 'change-me-to-a-secure-32-byte-secret!'
+}
+
+/**
+ * Wires every framework store token to a concrete backing implementation
+ * and installs HTTP / JWT authentication on the supplied injector.
+ */
+export const setupStore = (injector: Injector): void => {
+  injector.bind(UserStore, ({ inject }) => inject(UsersFileStore))
+  injector.bind(SessionStore, ({ inject }) => inject(SessionsMemoryStore))
+  injector.bind(PasswordCredentialStore, ({ inject }) => inject(PasswordCredentialsFileStore))
+  injector.bind(PasswordResetTokenStore, ({ inject }) => inject(PasswordResetTokensMemoryStore))
+  injector.bind(RefreshTokenStore, ({ inject }) => inject(RefreshTokensMemoryStore))
 
   usePasswordPolicy(injector)
-  useHttpAuthentication(injector)
+  useHttpAuthentication(injector, { userDataSet: AuthorizedUserDataSet })
   useJwtAuthentication(injector, {
-    secret: process.env.JWT_SECRET || 'change-me-to-a-secure-32-byte-secret!',
+    secret: requireJwtSecret(),
     accessTokenExpirationSeconds: 60,
   })
 }

--- a/service/src/shutdown-handler.spec.ts
+++ b/service/src/shutdown-handler.spec.ts
@@ -1,0 +1,101 @@
+import { createInjector, type Injector } from '@furystack/inject'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { attachShutdownHandler } from './shutdown-handler.js'
+
+const SIGNALS = [
+  'exit',
+  'SIGINT',
+  'SIGQUIT',
+  'SIGTERM',
+  'SIGUSR1',
+  'SIGUSR2',
+  'uncaughtException',
+  'unhandledRejection',
+] as const
+
+type CapturedListeners = Map<(typeof SIGNALS)[number], (...args: unknown[]) => void>
+
+const captureListeners = (): CapturedListeners => {
+  const captured: CapturedListeners = new Map()
+  vi.spyOn(process, 'once').mockImplementation((event, listener) => {
+    if ((SIGNALS as readonly string[]).includes(event as string)) {
+      captured.set(event as (typeof SIGNALS)[number], listener as (...args: unknown[]) => void)
+    }
+    return process
+  })
+  return captured
+}
+
+describe('attachShutdownHandler', () => {
+  let injector: Injector
+  let exitSpy: ReturnType<typeof vi.spyOn>
+  let removeAllListenersSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    injector = createInjector()
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    removeAllListenersSpy = vi.spyOn(process, 'removeAllListeners').mockImplementation(() => process)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('registers a handler for every supported signal', async () => {
+    const captured = captureListeners()
+
+    await attachShutdownHandler(injector)
+
+    for (const signal of SIGNALS) {
+      expect(captured.has(signal), `expected handler for ${signal}`).toBe(true)
+    }
+  })
+
+  it('disposes the injector and exits with code 0 on a graceful signal', async () => {
+    const captured = captureListeners()
+    const disposeSpy = vi.spyOn(injector, Symbol.asyncDispose).mockResolvedValue(undefined)
+
+    await attachShutdownHandler(injector)
+
+    const handler = captured.get('SIGINT')
+    expect(handler).toBeDefined()
+
+    handler?.()
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled())
+
+    expect(removeAllListenersSpy).toHaveBeenCalledWith('exit')
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
+  it('disposes the injector and exits with code 1 on an uncaught exception', async () => {
+    const captured = captureListeners()
+    const disposeSpy = vi.spyOn(injector, Symbol.asyncDispose).mockResolvedValue(undefined)
+
+    await attachShutdownHandler(injector)
+
+    const handler = captured.get('uncaughtException')
+    expect(handler).toBeDefined()
+
+    handler?.(new Error('boom'))
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled())
+
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('forces exit(1) when injector disposal throws', async () => {
+    const captured = captureListeners()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.spyOn(injector, Symbol.asyncDispose).mockRejectedValue(new Error('dispose-failed'))
+
+    await attachShutdownHandler(injector)
+
+    const handler = captured.get('SIGTERM')
+    handler?.()
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled())
+
+    expect(errorSpy).toHaveBeenCalledWith('Error during shutdown', expect.any(Error))
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+})

--- a/service/src/shutdown-handler.ts
+++ b/service/src/shutdown-handler.ts
@@ -1,40 +1,33 @@
 import type { Injector } from '@furystack/inject'
 import { getLogger } from '@furystack/logging'
-import { ServerManager } from '@furystack/rest-service'
 
-export const attachShutdownHandler = async (i: Injector) => {
+type ExitDetails = { code: number; reason: string; error?: unknown }
+
+/**
+ * Wires graceful shutdown to the standard process signals. Disposing the
+ * injector triggers every registered `onDispose` hook (HTTP server pool,
+ * stores, schedulers, …) before the process exits.
+ */
+export const attachShutdownHandler = async (i: Injector): Promise<void> => {
   const logger = getLogger(i).withScope('shutdown-handler')
 
   await logger.information({ message: '💤  Attaching shutdown handler...' })
 
-  const onExit = async ({ code, reason, error }: { code: number; reason: string; error?: any }) => {
+  const onExit = async ({ code, reason, error }: ExitDetails): Promise<void> => {
     process.removeAllListeners('exit')
     try {
       if (code) {
+        const errorMessage = error instanceof Error ? error.message : undefined
+        const errorStack = error instanceof Error ? error.stack : undefined
         await logger.fatal({
           message: `Something bad happened, starting shutdown with code '${code}' due '${reason}'`,
-          data: {
-            code,
-            reason,
-            error,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            errorMessage: error?.message,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            errorStack: error?.stack,
-          },
+          data: { code, reason, error, errorMessage, errorStack },
         })
       } else {
         await logger.information({
           message: `Shutting down gracefully due '${reason}'`,
-          data: {
-            code,
-            reason,
-            error,
-          },
+          data: { code, reason, error },
         })
-      }
-      if (i.cachedSingletons.get(ServerManager)) {
-        await i.getInstance(ServerManager)[Symbol.asyncDispose]()
       }
       await i[Symbol.asyncDispose]()
     } catch (e) {
@@ -45,20 +38,11 @@ export const attachShutdownHandler = async (i: Injector) => {
   }
 
   process.once('exit', () => void onExit({ code: 0, reason: 'exit' }))
-
-  // catches ctrl+c event
   process.once('SIGINT', () => void onExit({ code: 0, reason: 'SIGINT' }))
   process.once('SIGQUIT', () => void onExit({ code: 0, reason: 'SIGQUIT' }))
   process.once('SIGTERM', () => void onExit({ code: 0, reason: 'SIGTERM' }))
-
-  // catches "kill pid" (for example: nodemon restart)
   process.once('SIGUSR1', () => void onExit({ code: 0, reason: 'SIGUSR1' }))
   process.once('SIGUSR2', () => void onExit({ code: 0, reason: 'SIGUSR2' }))
-
-  // catches uncaught exceptions
-  process.once('uncaughtException', (error) => {
-    void onExit({ code: 1, reason: 'uncaughtException', error })
-  })
-
+  process.once('uncaughtException', (error) => void onExit({ code: 1, reason: 'uncaughtException', error }))
   process.once('unhandledRejection', (error) => void onExit({ code: 1, reason: 'unhandledRejection', error }))
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,8 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "incremental": true /* Enable incremental compilation */,
     "target": "ES2022",
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -16,7 +14,6 @@
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    "composite": true /* Enable project compilation */,
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -46,7 +43,6 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     "types": ["node"],
-    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
@@ -61,5 +57,11 @@
     "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
     "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */,
     "skipLibCheck": true
-  }
+  },
+  "files": [],
+  "references": [
+    { "path": "./common" },
+    { "path": "./service" },
+    { "path": "./frontend" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,9 +59,5 @@
     "skipLibCheck": true
   },
   "files": [],
-  "references": [
-    { "path": "./common" },
-    { "path": "./service" },
-    { "path": "./frontend" }
-  ]
+  "references": [{ "path": "./common" }, { "path": "./service" }, { "path": "./frontend" }]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -22,7 +22,7 @@ export default defineConfig({
       {
         test: {
           name: 'Frontend',
-          environment: 'jsdom',
+          environment: 'happy-dom',
           include: ['frontend/src/**/*.spec.(ts|tsx)'],
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,171 +418,172 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@furystack/auth-jwt@npm:^3.0.0":
+"@furystack/auth-jwt@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@furystack/auth-jwt@npm:4.0.0"
+  dependencies:
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/repository": "npm:^11.0.0"
+    "@furystack/rest": "npm:^10.0.0"
+    "@furystack/rest-client-fetch": "npm:^9.0.0"
+    "@furystack/rest-service": "npm:^14.0.0"
+    "@furystack/security": "npm:^8.0.0"
+    "@furystack/utils": "npm:^9.0.0"
+  checksum: 10c0/23fc20b804d143c0889b2737951773a5cd55abd4eb443cd124bbcd9f9272a1a487d3967237bd9186f597c193a9c6584cad32baad47908523d6b601e885a32045
+  languageName: node
+  linkType: hard
+
+"@furystack/cache@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@furystack/cache@npm:7.0.0"
+  dependencies:
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/utils": "npm:^9.0.0"
+  checksum: 10c0/a21930b6b20ad1c20edae86a8fb950d97f8a08b262faa405e164d0af4a4f4769e1818df1395fb6a9f2491c5daea4c2943993e3baadc84c0b67b7725be77b95b0
+  languageName: node
+  linkType: hard
+
+"@furystack/core@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@furystack/core@npm:17.0.0"
+  dependencies:
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/utils": "npm:^9.0.0"
+  checksum: 10c0/f8b09833945bd54be8a4378c27e62cd9349f591b4c65d993fa4a3e4d1442c1721351c6b8baee4a60ec393d556c055c8c5bec967c5cd98c8667e0937b2a7d32d8
+  languageName: node
+  linkType: hard
+
+"@furystack/eslint-plugin@npm:^3.0.0":
   version: 3.0.0
-  resolution: "@furystack/auth-jwt@npm:3.0.0"
-  dependencies:
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/repository": "npm:^10.1.11"
-    "@furystack/rest": "npm:^9.0.0"
-    "@furystack/rest-client-fetch": "npm:^8.1.8"
-    "@furystack/rest-service": "npm:^13.0.0"
-    "@furystack/security": "npm:^7.0.9"
-    "@furystack/utils": "npm:^8.2.5"
-  checksum: 10c0/509b2f53bb5f8e020c8ecf7cf227d55468611a80b2178179d8062aee9df702b7987c155dab1785ff97385097e4cd73425f3dab6aa8d8fc649f9bf62a08ee16f7
-  languageName: node
-  linkType: hard
-
-"@furystack/cache@npm:^6.1.5":
-  version: 6.1.5
-  resolution: "@furystack/cache@npm:6.1.5"
-  dependencies:
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/utils": "npm:^8.2.5"
-  checksum: 10c0/4c4bb18001192d052dc6f66538a45cfb9a4f422a8e84cf1c07024e3a927d6eb8f3c59302bd4391b3da69b88480d652d3bbcc6212709978385ff28b5a606780b0
-  languageName: node
-  linkType: hard
-
-"@furystack/core@npm:^16.0.4":
-  version: 16.0.4
-  resolution: "@furystack/core@npm:16.0.4"
-  dependencies:
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/utils": "npm:^8.2.5"
-  checksum: 10c0/d5f1e67019032eb42d51147e93fa611c2ff328957e88a46ae33d9f431f02800a8345e58d3553227bb8c78c42b45dbdddccef30d2e5c1fee6cc9e403a3de5067b
-  languageName: node
-  linkType: hard
-
-"@furystack/eslint-plugin@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@furystack/eslint-plugin@npm:2.2.0"
+  resolution: "@furystack/eslint-plugin@npm:3.0.0"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.58.2"
   peerDependencies:
     eslint: ">=9.0.0"
-  checksum: 10c0/42325057334beb424880068e2abc9fb80fb91ba4377e1d8a74f29c8a45b9e2107130a4702e2cfbe76a4b1aac2e41e2f8e69deb58f2c1810e41560b1a0f38a9c4
+  checksum: 10c0/2ab3f1bb996a306cdd4ce6a1f4474afc02e6124cad5a991639575e3a6fa0c85ba441c05c864e399a9e974daf023ab1f5f089155639d552561fc608a1120a4567
   languageName: node
   linkType: hard
 
-"@furystack/filesystem-store@npm:^7.1.7":
-  version: 7.1.7
-  resolution: "@furystack/filesystem-store@npm:7.1.7"
+"@furystack/filesystem-store@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@furystack/filesystem-store@npm:8.0.0"
   dependencies:
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/utils": "npm:^8.2.5"
-  checksum: 10c0/55af33a807fea80f2d76fdf4af86ac32da59712108e8105acd9733917290d964ccee3cadf87084c6f970f3ef7fc58c4912e4dc368f11d60767cac6423183fa71
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/utils": "npm:^9.0.0"
+  checksum: 10c0/5adb570dfd7713f84c59c6c05466bcbedab1ed13b4b62b9091820adb82dfddfa7aad21e7c74ac046d52d6997391a28ec8e99b1f87bd74a3c5d653fe7c2148c4a
   languageName: node
   linkType: hard
 
-"@furystack/inject@npm:^12.0.36":
-  version: 12.0.36
-  resolution: "@furystack/inject@npm:12.0.36"
-  dependencies:
-    "@furystack/utils": "npm:^8.2.5"
-  checksum: 10c0/bf85e17f7b53e0cd4d3866aca652e7cfe0f144032d6fd8a59df458f507f9d8db3958667b75a4504fb386c9afbedfdb0b6b280e4649d855b8946780929f8aa968
-  languageName: node
-  linkType: hard
-
-"@furystack/logging@npm:^8.1.5":
-  version: 8.1.5
-  resolution: "@furystack/logging@npm:8.1.5"
-  dependencies:
-    "@furystack/inject": "npm:^12.0.36"
-  checksum: 10c0/c6009ee1b3f7b0f82f446cd4b962d05c9fafaa5c9cb3993bdd888f5ee2284c4ce9465f1bd758b302d79d9682c7ff44f46fb598825b60c27206ecf42d9093da09
-  languageName: node
-  linkType: hard
-
-"@furystack/repository@npm:^10.1.11":
-  version: 10.1.11
-  resolution: "@furystack/repository@npm:10.1.11"
-  dependencies:
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/utils": "npm:^8.2.5"
-  checksum: 10c0/e29ed478a585060348209adda5bd15a9447d076c75aa57351f1a35f02697f940dd64f9643e8183f4a3baa56388d586c14bb19151dc303b286c52ce761c5b50e1
-  languageName: node
-  linkType: hard
-
-"@furystack/rest-client-fetch@npm:^8.1.8":
-  version: 8.1.8
-  resolution: "@furystack/rest-client-fetch@npm:8.1.8"
-  dependencies:
-    "@furystack/rest": "npm:^9.0.0"
-    path-to-regexp: "npm:^8.4.2"
-  checksum: 10c0/b79dadfbd1655ee4af243f4289a0b3c82621b80b6ce183d97292aa714c873a0370e37b1664b08eb8cb1f2b79837bca5be885e6a27b3cced7c96da0fa8efcd1fe
-  languageName: node
-  linkType: hard
-
-"@furystack/rest-service@npm:^13.0.0":
+"@furystack/inject@npm:^13.0.0":
   version: 13.0.0
-  resolution: "@furystack/rest-service@npm:13.0.0"
+  resolution: "@furystack/inject@npm:13.0.0"
   dependencies:
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/repository": "npm:^10.1.11"
-    "@furystack/rest": "npm:^9.0.0"
-    "@furystack/security": "npm:^7.0.9"
-    "@furystack/utils": "npm:^8.2.5"
+    "@furystack/utils": "npm:^9.0.0"
+  checksum: 10c0/e35095ae20abecbb31b72bdf3c147fea260af01b1fc8164b0c0f867d21226dae6faad7d738c8a786efb15e063d10fef186ae2e31a4db337afb847c6a54e75022
+  languageName: node
+  linkType: hard
+
+"@furystack/logging@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@furystack/logging@npm:9.0.0"
+  dependencies:
+    "@furystack/inject": "npm:^13.0.0"
+  checksum: 10c0/9dfa64c48750fccc38bb9050a6118e82b8f560743480fb728e3a4a81866f1e14c89de8d8f127060339cdf8458a31239308b05e83de3aa61b0c00129300588b3c
+  languageName: node
+  linkType: hard
+
+"@furystack/repository@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "@furystack/repository@npm:11.0.0"
+  dependencies:
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/utils": "npm:^9.0.0"
+  checksum: 10c0/b4682cd99032a4efde5c992ada79fba8223a511888d394ef3c58f2254ef838f9fd66e6d791498734914257223ff24d675c05a97fb15cbdf6f95ecbcb4aa5604d
+  languageName: node
+  linkType: hard
+
+"@furystack/rest-client-fetch@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@furystack/rest-client-fetch@npm:9.0.0"
+  dependencies:
+    "@furystack/rest": "npm:^10.0.0"
+    path-to-regexp: "npm:^8.4.2"
+  checksum: 10c0/00b50e9c83d7ae3bcb8ed9cd059cb13c4102fffa1181c8991b8c6e7de613be3f181bb3959c8281d1232c0df6573c99a20e1fa886cca2c51d5283e98175db2515
+  languageName: node
+  linkType: hard
+
+"@furystack/rest-service@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@furystack/rest-service@npm:14.0.0"
+  dependencies:
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/repository": "npm:^11.0.0"
+    "@furystack/rest": "npm:^10.0.0"
+    "@furystack/security": "npm:^8.0.0"
+    "@furystack/utils": "npm:^9.0.0"
     ajv: "npm:^8.18.0"
     ajv-formats: "npm:^3.0.1"
     path-to-regexp: "npm:^8.4.2"
-  checksum: 10c0/83ae4a1741b71f9f5026c4fd3f7e2778908f625d41b05c6c22bc4d4e1d48182c67ba38185168ad95c5d536b6d3f7e3b3e007b8cac2c5ce4935ddbe22d8295975
+  checksum: 10c0/253b3a080b454fd4e2379658dda1e92091318af03c8c3f985f61c22162f9a6d695195149fc4dc83efd5fa836b9a3d33f2d9ded6b1719499fcf635ba376d43dbb
   languageName: node
   linkType: hard
 
-"@furystack/rest@npm:^9.0.0":
+"@furystack/rest@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@furystack/rest@npm:10.0.0"
+  dependencies:
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+  checksum: 10c0/67e74388bb7664a2f8be963732023773d33c7c2bdc3a920d7dffdfda17e9f0fc4e8b0ea26061d42aa9140b5ae92b9b2eab5b05cd26e14cb81a3a8ec59609bcf8
+  languageName: node
+  linkType: hard
+
+"@furystack/security@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@furystack/security@npm:8.0.0"
+  dependencies:
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/repository": "npm:^11.0.0"
+  checksum: 10c0/0d188d0a794742496ce657a36c20eb2956f092f1c71364a262427470f3783a43b525485bd9bf18d815d4c74a4bd703d0361ecaab49757871a5a9c328e7956f55
+  languageName: node
+  linkType: hard
+
+"@furystack/shades-common-components@npm:^17.0.0":
+  version: 17.0.0
+  resolution: "@furystack/shades-common-components@npm:17.0.0"
+  dependencies:
+    "@furystack/cache": "npm:^7.0.0"
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/shades": "npm:^15.0.0"
+    "@furystack/utils": "npm:^9.0.0"
+    path-to-regexp: "npm:^8.4.2"
+  checksum: 10c0/fbda2fa587fcead41d65781d7752179c8ba5e01854f16fa97af3e3e0d7989c18609520bb183afe7f3b158143f7aad2f5a0e87598a4303b56afe7a5a91b8bb0c0
+  languageName: node
+  linkType: hard
+
+"@furystack/shades@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "@furystack/shades@npm:15.0.0"
+  dependencies:
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/rest": "npm:^10.0.0"
+    "@furystack/utils": "npm:^9.0.0"
+    path-to-regexp: "npm:^8.4.2"
+  checksum: 10c0/f69c60eee18f5e34ef2a9c80e4d651c2bfa8e40894b8a2d9f12901598fc3b62dbc05addd569cecd3ed3c0f3bee10b6c0e00883e4d4e70e4ed71770ec467fc1cb
+  languageName: node
+  linkType: hard
+
+"@furystack/utils@npm:^9.0.0":
   version: 9.0.0
-  resolution: "@furystack/rest@npm:9.0.0"
-  dependencies:
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-  checksum: 10c0/cb18ee4fc2d6d3c027b7858f8a9132f8a5a257550b454b280dcf718e9cc6371e3513bb6ef7d596eceee298d5318124bcf6251d25045f87024e55659479cd7ca7
-  languageName: node
-  linkType: hard
-
-"@furystack/security@npm:^7.0.9":
-  version: 7.0.9
-  resolution: "@furystack/security@npm:7.0.9"
-  dependencies:
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/repository": "npm:^10.1.11"
-  checksum: 10c0/09410e400a23dbc1007be6ed197fa138f69ffb1258b366decd8e44546a9423db01833942b5f3c901fd959e51f3918c20ec875f6deb0bf43881cd24fc8b9e64b0
-  languageName: node
-  linkType: hard
-
-"@furystack/shades-common-components@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "@furystack/shades-common-components@npm:16.0.0"
-  dependencies:
-    "@furystack/cache": "npm:^6.1.5"
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/shades": "npm:^14.0.0"
-    "@furystack/utils": "npm:^8.2.5"
-    path-to-regexp: "npm:^8.4.2"
-  checksum: 10c0/6eb5abe81de0e0486711f0bf810fe1cfe65adc9de1c7b96d87dd35ff4429329d630848bae34c7da891329dab4937c566b21b3079c799b6a5033a6e248586aca8
-  languageName: node
-  linkType: hard
-
-"@furystack/shades@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "@furystack/shades@npm:14.0.0"
-  dependencies:
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/rest": "npm:^9.0.0"
-    "@furystack/utils": "npm:^8.2.5"
-    path-to-regexp: "npm:^8.4.2"
-  checksum: 10c0/1ddd423391428e0f4b6e0389515ba2a1410708ea9f60509e16f0bc6c2b130f778582168e2fad3fde37ccd76ca0c102773a00c6276d59f31adf00876288c3f07f
-  languageName: node
-  linkType: hard
-
-"@furystack/utils@npm:^8.2.5":
-  version: 8.2.5
-  resolution: "@furystack/utils@npm:8.2.5"
-  checksum: 10c0/66ae042f4c82b67763ea7c52abd0a2f8290bbf1ac5dc1f89373f49d87ef9e6733eb56bb61a21ccc2ed9137078a152c8ce3da7f28cbd207c2ef4f20be4100dd45
+  resolution: "@furystack/utils@npm:9.0.0"
+  checksum: 10c0/84469ba2b36a876bc79200a4f1ef72795356d0a98197057f54c98e3db2481cf57f97ee74387a692f45be10861619a60a5ccd2ab76a71c8b629d7b83b0976751f
   languageName: node
   linkType: hard
 
@@ -2702,7 +2703,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "common@workspace:common"
   dependencies:
-    "@furystack/rest": "npm:^9.0.0"
+    "@furystack/rest": "npm:^10.0.0"
     "@types/node": "npm:^25.6.0"
     ts-json-schema-generator: "npm:^2.9.0"
     vitest: "npm:^4.1.5"
@@ -3525,14 +3526,14 @@ __metadata:
   resolution: "frontend@workspace:frontend"
   dependencies:
     "@codecov/vite-plugin": "npm:^2.0.1"
-    "@furystack/auth-jwt": "npm:^3.0.0"
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/logging": "npm:^8.1.5"
-    "@furystack/rest-client-fetch": "npm:^8.1.8"
-    "@furystack/shades": "npm:^14.0.0"
-    "@furystack/shades-common-components": "npm:^16.0.0"
-    "@furystack/utils": "npm:^8.2.5"
+    "@furystack/auth-jwt": "npm:^4.0.0"
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/logging": "npm:^9.0.0"
+    "@furystack/rest-client-fetch": "npm:^9.0.0"
+    "@furystack/shades": "npm:^15.0.0"
+    "@furystack/shades-common-components": "npm:^17.0.0"
+    "@furystack/utils": "npm:^9.0.0"
     "@types/node": "npm:^25.6.0"
     common: "workspace:^"
     typescript: "npm:^6.0.3"
@@ -3628,7 +3629,7 @@ __metadata:
   resolution: "furystack-boilerplate-app@workspace:."
   dependencies:
     "@eslint/js": "npm:^10.0.1"
-    "@furystack/eslint-plugin": "npm:^2.2.0"
+    "@furystack/eslint-plugin": "npm:^3.0.0"
     "@furystack/yarn-plugin-changelog": "npm:^1.0.10"
     "@playwright/test": "npm:^1.59.1"
     "@types/node": "npm:^25.6.0"
@@ -5865,14 +5866,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "service@workspace:service"
   dependencies:
-    "@furystack/auth-jwt": "npm:^3.0.0"
-    "@furystack/core": "npm:^16.0.4"
-    "@furystack/filesystem-store": "npm:^7.1.7"
-    "@furystack/inject": "npm:^12.0.36"
-    "@furystack/logging": "npm:^8.1.5"
-    "@furystack/repository": "npm:^10.1.11"
-    "@furystack/rest-service": "npm:^13.0.0"
-    "@furystack/security": "npm:^7.0.9"
+    "@furystack/auth-jwt": "npm:^4.0.0"
+    "@furystack/core": "npm:^17.0.0"
+    "@furystack/filesystem-store": "npm:^8.0.0"
+    "@furystack/inject": "npm:^13.0.0"
+    "@furystack/logging": "npm:^9.0.0"
+    "@furystack/repository": "npm:^11.0.0"
+    "@furystack/rest-service": "npm:^14.0.0"
+    "@furystack/security": "npm:^8.0.0"
     "@types/node": "npm:^25.6.0"
     common: "workspace:^"
     typescript: "npm:^6.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,7 +1201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^25.6.0":
+"@types/node@npm:*, @types/node@npm:>=20.0.0, @types/node@npm:^25.6.0":
   version: 25.6.0
   resolution: "@types/node@npm:25.6.0"
   dependencies:
@@ -1239,6 +1239,22 @@ __metadata:
   version: 1.0.3
   resolution: "@types/treeify@npm:1.0.3"
   checksum: 10c0/758902638ff83a790c13359729d77aeb80aae50f7039670037e3a0ba2bcc7b09dd49173ab21a96946d83af1682fcd70e448e49151ecd46e190f8925077142d4a
+  languageName: node
+  linkType: hard
+
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10c0/dad39d1e4abe760a0a963c84bbdbd26b1df0eb68aff83bdf6ecbb50ad781ead777f6906d19a87007790b750f7500a12e5624d31fc6a1529d14bd19b5c3a316d1
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -2938,6 +2954,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "entities@npm:7.0.1"
+  checksum: 10c0/b4fb9937bb47ecb00aaaceb9db9cdd1cc0b0fb649c0e843d05cf5dbbd2e9d2df8f98721d8b1b286445689c72af7b54a7242fc2d63ef7c9739037a8c73363e7ca
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -3640,6 +3663,7 @@ __metadata:
     eslint-plugin-jsdoc: "npm:^62.9.0"
     eslint-plugin-playwright: "npm:^2.10.2"
     eslint-plugin-prettier: "npm:^5.5.5"
+    happy-dom: "npm:^20.9.0"
     husky: "npm:^9.1.7"
     lint-staged: "npm:^16.4.0"
     prettier: "npm:^3.8.3"
@@ -3848,6 +3872,20 @@ __metadata:
   version: 1.0.4
   resolution: "grapheme-splitter@npm:1.0.4"
   checksum: 10c0/108415fb07ac913f17040dc336607772fcea68c7f495ef91887edddb0b0f5ff7bc1d1ab181b125ecb2f0505669ef12c9a178a3bbd2dd8e042d8c5f1d7c90331a
+  languageName: node
+  linkType: hard
+
+"happy-dom@npm:^20.9.0":
+  version: 20.9.0
+  resolution: "happy-dom@npm:20.9.0"
+  dependencies:
+    "@types/node": "npm:>=20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
+    "@types/ws": "npm:^8.18.1"
+    entities: "npm:^7.0.1"
+    whatwg-mimetype: "npm:^3.0.0"
+    ws: "npm:^8.18.3"
+  checksum: 10c0/4fb814057b85d13d9459c1af39de28d6e7504ba99c12123179e6c69d8c3e1cbd8c48c4104c7d793e89d7aa1b5f360a8e72ad56d33cc23cc6f42a27e2fbd25748
   languageName: node
   linkType: hard
 
@@ -6845,6 +6883,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
+  languageName: node
+  linkType: hard
+
 "which-boxed-primitive@npm:^1.1.0, which-boxed-primitive@npm:^1.1.1":
   version: 1.1.1
   resolution: "which-boxed-primitive@npm:1.1.1"
@@ -7019,6 +7064,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.20.0
+  resolution: "ws@npm:8.20.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🧩 Functional DI Migration

Aligns the boilerplate with the v7 functional-DI release across `@furystack/inject`, `@furystack/core`, `@furystack/repository`, `@furystack/rest-service`, `@furystack/auth-jwt`, `@furystack/security`, `@furystack/shades`, `@furystack/shades-common-components`, and friends. Decorator-based services are gone; everything resolves through `defineService` tokens.

## 🛠 Service

- `setup-store.ts`: `defineFileSystemStore` / `defineStore` for backing stores; framework tokens (`UserStore`, `SessionStore`, `PasswordCredentialStore`, `PasswordResetTokenStore`, `RefreshTokenStore`) bound on the injector. `User` dataset moved to a dedicated `AuthorizedUserDataSet` token shared with the seeder.
- `setup-rest-api.ts`: `LoginAction` → `createPasswordLoginAction(createCookieLoginStrategy(injector))`.
- `seed.ts`: token-based `getDataSetFor`, `injector.get(PasswordAuthenticator)`.
- `shutdown-handler.ts`: dropped `ServerManager` lookup; sole disposal goes through `injector[Symbol.asyncDispose]`.
- `root-injector.ts`: `createInjector()`.
- `requireJwtSecret()` throws when `NODE_ENV=production` and `JWT_SECRET` is missing or < 32 bytes.

## 🎨 Frontend

- `SessionService` and `BoilerplateApiClient` rewritten as `defineService` singleton tokens. Disposal registered via `onDispose`, eager `void init()` wires bootstrap (fixes dead `init()`).
- All `injector.getInstance(X)` call sites switched to `injector.get(X)`.
- `NestedRouteLink` `href` → `path`.
- Null-checked `document.getElementById('root')`.

## 🧰 Tooling

- `frontend/tsconfig.json` now `extends ../tsconfig.json`; removed redundant compiler options.
- `tsconfig.json` reformatted (Prettier).
- `eslint.config.js` adds `parserOptions.projectService.allowDefaultProject` for `vite.config.ts`, `vitest.config.mts`, `playwright.config.ts`, and `e2e/*.spec.ts`.
